### PR TITLE
Add a data retention cron

### DIFF
--- a/src/sprout/Controllers/RetentionCronController.php
+++ b/src/sprout/Controllers/RetentionCronController.php
@@ -1,0 +1,71 @@
+<?php
+/*
+ * Copyright (C) 2017 Karmabunny Pty Ltd.
+ *
+ * This file is a part of SproutCMS.
+ *
+ * SproutCMS is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU General Public License as published by the Free Software Foundation, either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * For more information, visit <http://getsproutcms.com>.
+ */
+
+namespace Sprout\Controllers;
+
+use DateTime;
+use InvalidArgumentException;
+
+use Sprout\Helpers\Cron;
+use Sprout\Helpers\Pdb;
+use Sprout\Helpers\Register;
+
+class RetentionCronController extends Controller
+{
+    /**
+     * Purge old data from the nominated tables
+     */
+    public function cronRetention()
+    {
+        Cron::start('Retention');
+
+        $jobs = Register::getRetentionJobs();
+        Cron::message('Purging old data for ' . count($jobs) . ' table(s)');
+
+        $now = new DateTime();
+        foreach ($jobs as $job_spec) {
+            Pdb::validateIdentifier($job_spec['table']);
+            Pdb::validateIdentifier($job_spec['column']);
+
+            // Ensure they haven't provided a negative interval as this will cause the
+            // threshold to move forward in time.
+            if ($job_spec['min_age']->invert) {
+                throw new InvalidArgumentException("Minimum age specification for {$table_name} retention job must be positive");
+            }
+
+            $threshold = clone $now;
+            $threshold->sub($job_spec['min_age']);
+            $threshold = $threshold->format('Y-m-d H:i:s');
+
+            Cron::message("Purging records from '{$job_spec['table']}' ({$job_spec['column']}) updated before {$threshold}");
+
+            $conds = [
+                [$job_spec['column'], '<', $threshold]
+            ];
+
+            if (count($job_spec['extra_conds'])) {
+                $conds += $job_spec['extra_conds'];
+            }
+
+            $params = [];
+            $where = Pdb::buildClause($conds, $params);
+
+            $q = "DELETE FROM ~{$job_spec['table']} WHERE {$where}";
+            $count = Pdb::q($q, $params, 'count');
+
+            Cron::message("    - Deleted {$count} records");
+        }
+
+        Cron::success();
+    }
+}

--- a/src/sprout/Helpers/Register.php
+++ b/src/sprout/Helpers/Register.php
@@ -16,6 +16,7 @@ namespace Sprout\Helpers;
 use Kohana;
 use Exception;
 use InvalidArgumentException;
+use DateInterval;
 
 
 
@@ -44,6 +45,7 @@ class Register
     private static $cron_jobs = [];
     private static $display_conditions = [];
     private static $search_handlers = [];
+    private static $retention_jobs = [];
 
 
     /**
@@ -645,5 +647,35 @@ class Register
         }
 
         return $handlers;
+    }
+
+    /**
+     * Register a retention job
+     *
+     * @param string $table_name The table that has a data retention limit
+     * @param string $age_column The column that determines a record's age
+     *                           e.g. date_added for immutable rows or date_modified for mutable
+     * @param DateInterval $minimum_age Minimum age of a record before it's eligible for deletion
+     * @param array $extra_conds Extra query conditions may be provided here, as used by Pdb::buildClause
+     *                           e.g. [['status', '=', 'success']] to delete only successful jobs
+     */
+    public static function retentionJob($table_name, $age_column, DateInterval $minimum_age, array $extra_conds = [])
+    {
+        static::$retention_jobs[] = [
+            'table' => $table_name,
+            'column' => $age_column,
+            'min_age' => $minimum_age,
+            'extra_conds' => $extra_conds,
+        ];
+    }
+
+    /**
+     * Get the currently registered retention jobs
+     *
+     * @return array An array of [table, column, min_age, extra_conds]
+     */
+    public static function getRetentionJobs()
+    {
+        return static::$retention_jobs;
     }
 }

--- a/src/sprout/Helpers/WorkerCtrl.php
+++ b/src/sprout/Helpers/WorkerCtrl.php
@@ -52,10 +52,6 @@ class WorkerCtrl
             throw new InvalidArgumentException('Provided class is not a subclass of "Worker".');
         }
 
-        // Do some self cleanup
-        $q = "DELETE FROM ~worker_jobs WHERE DATE_ADD(date_modified, INTERVAL 6 MONTH) < NOW()";
-        Pdb::query($q, [], 'null');
-
         $args = func_get_args();
         array_shift($args);
 

--- a/src/sprout/core/Kohana.php
+++ b/src/sprout/core/Kohana.php
@@ -688,7 +688,6 @@ final class Kohana {
     public static function logException($exception)
     {
         static $insert; // PDOStatement
-        static $delete; // PDOStatement
 
         $conn = Pdb::getConnection();
 
@@ -701,9 +700,6 @@ final class Kohana {
                 VALUES
                 (:date, :class, :message, :exception, :trace, :server, :get, :session)";
             $insert = $conn->prepare($insert_q);
-
-            $delete_q = "DELETE FROM {$table} WHERE date_generated < DATE_SUB(?, INTERVAL 10 DAY)";
-            $delete = $conn->prepare($delete_q);
         }
 
         // Extract private attributes from Exception which serialize() would provide
@@ -731,9 +727,6 @@ final class Kohana {
         ]);
         $log_id = $conn->lastInsertId();
         $insert->closeCursor();
-
-        $delete->execute([Pdb::now()]);
-        $delete->closeCursor();
 
         return $log_id;
     }

--- a/src/sprout/sprout_load.php
+++ b/src/sprout/sprout_load.php
@@ -65,8 +65,14 @@ Register::cronJob('daily', 'Sprout\\Controllers\\RetentionCronController', 'cron
 // Purge exception log entries after 14 days
 Register::retentionJob('exception_log', 'date_generated', new DateInterval('P14D'));
 
+// Purge rate limit hits after 14 days
+Register::retentionJob('rate_limit_hits', 'date_added', new DateInterval('P14D'));
+
 // Purge worker jobs after 6 months
 Register::retentionJob('worker_jobs', 'date_modified', new DateInterval('P6M'));
+
+// Purge login attempts after 6 months
+Register::retentionJob('login_attempts', 'date_added', new DateInterval('P6M'));
 
 
 Register::displayCondition('Sprout\\Helpers\\DisplayConditions\\Platform\\DeviceCategory', 'Platform', 'Device category');

--- a/src/sprout/sprout_load.php
+++ b/src/sprout/sprout_load.php
@@ -59,6 +59,8 @@ Register::cronJob('daily', 'Sprout\\Controllers\\AdminController', 'cronGenericA
 Register::cronJob('daily', 'Sprout\\Controllers\\Admin\\FileAdminController', 'cronCleanupInvalid');
 Register::cronJob('daily', 'Sprout\\Controllers\\ContentSubscribeController', 'cronSendSubscriptions');
 Register::cronJob('daily', 'Sprout\\Controllers\\Admin\\ActionLogAdminController', 'cronCleanup');
+Register::cronJob('daily', 'Sprout\\Controllers\\RetentionCronController', 'cronRetention');
+
 
 Register::displayCondition('Sprout\\Helpers\\DisplayConditions\\Platform\\DeviceCategory', 'Platform', 'Device category');
 Register::displayCondition('Sprout\\Helpers\\DisplayConditions\\Platform\\BrowserName', 'Platform', 'Browser name');

--- a/src/sprout/sprout_load.php
+++ b/src/sprout/sprout_load.php
@@ -65,6 +65,9 @@ Register::cronJob('daily', 'Sprout\\Controllers\\RetentionCronController', 'cron
 // Purge exception log entries after 14 days
 Register::retentionJob('exception_log', 'date_generated', new DateInterval('P14D'));
 
+// Purge worker jobs after 6 months
+Register::retentionJob('worker_jobs', 'date_modified', new DateInterval('P6M'));
+
 
 Register::displayCondition('Sprout\\Helpers\\DisplayConditions\\Platform\\DeviceCategory', 'Platform', 'Device category');
 Register::displayCondition('Sprout\\Helpers\\DisplayConditions\\Platform\\BrowserName', 'Platform', 'Browser name');

--- a/src/sprout/sprout_load.php
+++ b/src/sprout/sprout_load.php
@@ -10,6 +10,7 @@
  *
  * For more information, visit <http://getsproutcms.com>.
  */
+use DateInterval;
 use Sprout\Helpers\I18n;
 use Sprout\Helpers\Pdb;
 use Sprout\Helpers\Register;
@@ -60,6 +61,9 @@ Register::cronJob('daily', 'Sprout\\Controllers\\Admin\\FileAdminController', 'c
 Register::cronJob('daily', 'Sprout\\Controllers\\ContentSubscribeController', 'cronSendSubscriptions');
 Register::cronJob('daily', 'Sprout\\Controllers\\Admin\\ActionLogAdminController', 'cronCleanup');
 Register::cronJob('daily', 'Sprout\\Controllers\\RetentionCronController', 'cronRetention');
+
+// Purge exception log entries after 14 days
+Register::retentionJob('exception_log', 'date_generated', new DateInterval('P14D'));
 
 
 Register::displayCondition('Sprout\\Helpers\\DisplayConditions\\Platform\\DeviceCategory', 'Platform', 'Device category');


### PR DESCRIPTION
This provides a simple, data driven interface to purging old data from tables.

I've moved exception log and worker job clean-up into retention jobs, which in the former case avoids a potentially lengthy operation (delete on MyIASM tables grows increasingly slow the more operations performed sans `OPTIMIZE TABLE`) occurring during a request.

Added new jobs for `rate_limit_hits` and `login_attempts` because we weren't cleaning these up.