### PR TITLE
JsonForm support for record ids in "args" arrays

### DIFF
--- a/src/sprout/Controllers/Controller.php
+++ b/src/sprout/Controllers/Controller.php
@@ -551,7 +551,7 @@ abstract class Controller {
         if ($mode == '') $mode = ($item_id == 0 ? 'add' : 'edit');
         $validator = new Validator($_POST);
         $this->autoSetEmptyParam($conf);
-        list($data, $errs) = JsonForm::collateData($conf, $mode, $validator);
+        list($data, $errs) = JsonForm::collateData($conf, $mode, $validator, $item_id);
 
         $this->jsonExtraValidate($item_id, $validator);
         $errs = array_merge($errs, $validator->getFieldErrors());


### PR DESCRIPTION
The system can possibly also support other data, through the use of a "metadata" array which is passed around from the top of the render into the inner parts.

Args arrays for validation, display methods, and function items are all supported.

To use an id in the args, use the magic string`%%` which is the same as other areas (itemlist, etc).

The system could support additional metadata fields and replacement strings (e.g. other field values, operator id, etc); these changes would occur in the method `JsonForm::argReplace`.

**Example usage:**
```
  "validate": [
      {
          "func": "Validity::uniqueValue",
          "args": ["organisations", "subdomain", "%%"]
      }
  ]
```

This would pass three arguments to the `Validity::uniqueValue` method, with the first two being static strings, and the last argument being the record id. A zero is passed for record adding.