### PR TITLE
Fix/multiedit conditions

### DIFF
--- a/src/sprout/Controllers/Controller.php
+++ b/src/sprout/Controllers/Controller.php
@@ -603,6 +603,10 @@ abstract class Controller {
                 $multi_data_key = 'multiedit_' . $multed['id'];
                 $link_column = !empty($multed['link']) ? $multed['link'] : $id_field;
 
+                $conditions = [];
+                if (isset($multed['where'])) $conditions = $multed['where'];
+                $conditions[] = [$link_column, '=', $item_id];
+
                 if (isset($data[$multi_data_key])) {
                     $defaults = [];
                     $field_defns = JsonForm::flattenGroups($multed['items']);
@@ -633,7 +637,7 @@ abstract class Controller {
                     $new_set = [];
                 }
 
-                $this->replaceSet($table, $new_set, [$link_column => $item_id]);
+                $this->replaceSet($table, $new_set, $conditions);
             }
         }
 

--- a/src/sprout/Helpers/JsonForm.php
+++ b/src/sprout/Helpers/JsonForm.php
@@ -53,12 +53,10 @@ class JsonForm extends Form
 
                 $values = [];
                 $table_conditions = [];
+                $link_column = !empty($multed['link']) ? $multed['link'] : $default_link;
 
-                if (!empty($multed['link'])) {
-                    $table_conditions[$multed['link']] = $record_id;
-                } else {
-                    $table_conditions[$default_link] = $record_id;
-                }
+                if (isset($multed['where'])) $table_conditions = $multed['where'];
+                $table_conditions[] = [$link_column, '=', $record_id];
 
                 $table_conditions = array_merge($table_conditions, $conditions);
                 $q = "SELECT * FROM ~{$table} WHERE " . Pdb::buildClause($table_conditions, $values);


### PR DESCRIPTION
DB where clause conditions array is part of json form spec for Multi-edits, but wasn't implemented for either loading of form data, nor when saving form data.

This patch fixes both loading and saving.

See docs for spec: http://docs.getsproutcms.com/creating-forms-overview/jsonform/multiedit
under "where:"