### PR TITLE
Feat/redis session handling

### DIFF
--- a/src/sprout/Helpers/Session.php
+++ b/src/sprout/Helpers/Session.php
@@ -117,8 +117,7 @@ class Session
         // Destroy any current sessions
         static::destroy();
 
-        if (Session::$config['driver'] !== 'native')
-        {
+        if (Session::$config['driver'] !== 'native' and Session::$config['driver'] !== 'redis') {
             // Set driver name
             $driver = 'Sprout\\Helpers\\Drivers\\Session\\' . ucfirst(Session::$config['driver']);
 
@@ -161,6 +160,11 @@ class Session
             Kohana::config('cookie.secure'),
             true    // never allow javascript to access session cookies
         );
+
+        // If redis is available then it's used for session storage
+        if (self::$config['driver'] == 'redis') {
+            Rdb::registerSessionHandler();
+        }
 
         // Start the session!
         session_start();
@@ -230,7 +234,7 @@ class Session
      */
     public static function regenerate()
     {
-        if (Session::$config['driver'] === 'native')
+        if (Session::$config['driver'] === 'native' or Session::$config['driver'] == 'redis')
         {
             // Generate a new session id
             // Note: also sets a new session cookie with the updated id

--- a/src/sprout/config/session.php
+++ b/src/sprout/config/session.php
@@ -17,7 +17,7 @@
 /**
  * @package Session
  *
- * Session driver name: native/database
+ * Session driver name: native/database/redis
  */
 $config['driver'] = 'native';
 


### PR DESCRIPTION
Enabling Redis session handling for Sprout3 with a single config tweak.

This approach is currently live in Maniax (Cloud) and a sprout2 implementation in Select Cornwall. 

I've also migrated TheyStay to this code with a local patch and a single entry session config in the app folder, which is working successfully.

There is a comment tweak in the core session config to hint at the new option.