### PR TITLE
Feat/http timeouts

### DIFF
--- a/src/sprout/Helpers/HttpReq.php
+++ b/src/sprout/Helpers/HttpReq.php
@@ -125,7 +125,7 @@ class HttpReq
             $http_opts['header'] = self::buildHeadersString($opts['headers']);
         }
 
-        if (!isset($opts['timeout'])) {
+        if (isset($opts['timeout'])) {
             $http_opts['timeout'] = (float) $opts['timeout'];
         }
 

--- a/src/sprout/Helpers/HttpReq.php
+++ b/src/sprout/Helpers/HttpReq.php
@@ -133,7 +133,8 @@ class HttpReq
         $response = @file_get_contents($url, 0, $context);
 
         $matches = null;
-        if (preg_match('/ ([0-9]+) /', $http_response_header[0], $matches)) {
+
+        if (preg_match('/ ([0-9]+) /', $http_response_header[0] ?? '', $matches)) {
             self::$http_status = $matches[1];
         } else {
             self::$http_status = null;

--- a/src/sprout/Helpers/HttpReq.php
+++ b/src/sprout/Helpers/HttpReq.php
@@ -106,7 +106,7 @@ class HttpReq
     /**
      * Sends a HTTP request using fopen (i.e. file_get_contents)
      */
-    private static function reqFopen($url, array $opts, $data = null)
+    protected static function reqFopen($url, array $opts, $data = null)
     {
         $http_opts = array(
             'method' => $opts['method'],
@@ -146,7 +146,7 @@ class HttpReq
     /**
      * Sends a HTTP request using cURL.
      */
-    private static function reqCurl($url, array $opts, $data = '')
+    protected static function reqCurl($url, array $opts, $data = '')
     {
         $ch = curl_init($url);
         $headers = [];


### PR DESCRIPTION
Easy stuff - now with tests!

Sprout should probably define a default time. We've been bitten by this more than once.
