### PR TITLE
Feat/admin cachebust

### DIFF
--- a/src/sprout/Helpers/Media.php
+++ b/src/sprout/Helpers/Media.php
@@ -1,0 +1,177 @@
+<?php
+/*
+ * Copyright (C) 2017 Karmabunny Pty Ltd.
+ *
+ * This file is a part of SproutCMS.
+ *
+ * SproutCMS is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU General Public License as published by the Free Software Foundation, either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * For more information, visit <http://getsproutcms.com>.
+ */
+
+namespace Sprout\Helpers;
+
+
+/**
+ * Helpers for resolving and loading media files.
+ *
+ * These are resource files from modules, skin or sprout. These are files are
+ * not necessarily accessible from the web root because they're located
+ * in the src/ or vendor/ folders.
+ *
+ * Resource files are expected to live in the `media/` folder of a
+ * module/skin/sprout. Inside this files are grouped into sub-folders by their
+ * type (js, css, images).
+ *
+ * For public access, files are served by the {@see MediaController}. This is
+ * accessible from the `ROOT/_media` prefix.
+ *
+ * When accessing files, the format is like: `{section}/{file}`. The group is
+ * determined automatically by the extension. Skin files will include the
+ * subsite code automatically.
+ *
+ * Note that sprout has _two_ media folders. This is simply a legacy
+ * holdover - there's no true distinction between the two.
+ *
+ * @see MediaController
+ */
+class Media
+{
+
+    /**
+     * Get the root file path for a section.
+     *
+     * This is a file path, not a URL. Instead prefix `ROOT/_media`.
+     *
+     * @param string $section
+     * @return string
+     */
+    public static function getRoot(string $section): string
+    {
+        if ($section === 'core') {
+            return COREPATH . 'media/';
+        }
+
+        if ($section === 'sprout') {
+            return APPPATH . 'media/';
+        }
+
+        if ($section === 'skin') {
+            $subsite = SubsiteSelector::$subsite_code;
+            return DOCROOT . "skin/{$subsite}/media/";
+        }
+
+        return DOCROOT . "modules/{$section}/media/";
+    }
+
+
+    /**
+     * The file group for a given file name.
+     *
+     * This is based on the file extension.
+     *
+     * @param string $name
+     * @return string
+     */
+    public static function getGroup(string $name): string
+    {
+        $matches = [];
+        if (preg_match('!\.(css|js)$!', $name, $matches)) {
+            return $matches[1];
+        }
+
+        // Just assume.
+        return 'images';
+    }
+
+
+    /**
+     * Get the file path of a resource.
+     *
+     * @param string $name like `{section}/{file}.js|css|etc`
+     * @return string absolute path
+     */
+    public static function path(string $name): string
+    {
+        [$section, $name] = explode('/', $name, 2) + [null, null];
+
+        // Assume it's a core file.
+        if (!$name) {
+            $section = 'core';
+            $name = $section;
+        }
+
+        $root = self::getRoot($section);
+        $group = self::getGroup($name);
+
+        return "{$root}/{$group}/{$name}";
+    }
+
+
+    /**
+     * Get the URL for a resource.
+     *
+     * @param string $name like `{section}/{file}.js|css|etc`
+     * @param int|null $ts timestamp override, otherwise file mtime
+     * @return string a relative URL (without ROOT/)
+     */
+    public static function url(string $name, int $ts = null): string
+    {
+        [$section, $name] = explode('/', $name, 2) + [null, null];
+
+        // Assume it's a core file.
+        if (!$name) {
+            $section = 'core';
+            $name = $section;
+        }
+
+        $root = self::getRoot($section);
+        $group = self::getGroup($name);
+
+        $mtime = $ts ?: @filemtime("{$root}/{$group}/{$name}") ?: time();
+        $url = "_media/{$section}/{$group}/{$name}?{$mtime}";
+
+        return $url;
+    }
+
+
+    /**
+     * Get a media tag for a file.
+     *
+     * This will return a <script> or <link> tag for the given file based on
+     * the file extension.
+     *
+     * @param string $name section/file.js|css
+     * @param array $extra_attrs
+     * @return string
+     */
+    public static function tag(string $name, array $extra_attrs = []): string
+    {
+        $ts = $extra_attrs['_ts'] ?? null;
+        unset($extra_attrs['_ts']);
+
+        $url = 'ROOT/' . self::url($name, $ts);
+        $group = self::getGroup($name);
+
+        if ($group === 'js') {
+            $extra_attrs['src'] = $url;
+            $extra_attrs['type'] ??= 'text/javascript';
+
+            return '<script ' . Html::attributes($extra_attrs) . '></script>';
+        }
+
+        if ($group === 'css') {
+            $extra_attrs['href'] = $url;
+            $extra_attrs['type'] ??= 'text/css';
+            $extra_attrs['rel'] ??= 'stylesheet';
+
+            return '<link ' . Html::attributes($extra_attrs) . '>';
+        }
+
+        $extra_attrs['src'] = $url;
+        return '<img ' . Html::attributes($extra_attrs) . '>';
+    }
+
+}

--- a/src/sprout/Helpers/Needs.php
+++ b/src/sprout/Helpers/Needs.php
@@ -198,15 +198,7 @@ class Needs
 
         [, $section, $name] = $matches;
 
-        if ($section === 'core') {
-            $root = COREPATH . 'media/';
-
-        } elseif ($section === 'sprout') {
-            $root = APPPATH . 'media/';
-
-        } else {
-            $root = DOCROOT . "modules/{$section}/media/";
-        }
+        $root = Media::getRoot($section);
 
         // JS files, minified take precedence.
         if ($mtime = @filemtime($root . "js/{$name}.min.js")) {

--- a/src/sprout/views/admin/login_layout.php
+++ b/src/sprout/views/admin/login_layout.php
@@ -16,9 +16,9 @@
 
 use Sprout\Helpers\Enc;
 use Sprout\Helpers\Jquery;
+use Sprout\Helpers\Media;
 use Sprout\Helpers\Notification;
 use Sprout\Helpers\Sprout;
-
 
 $merged_js = 'media/merged/admin.' . Sprout::getVersion() . '.js';
 $merged_css = 'media/merged/admin.' . Sprout::getVersion() . '.css';
@@ -41,22 +41,22 @@ $merged_css = 'media/merged/admin.' . Sprout::getVersion() . '.css';
     var SITE = 'SITE/';
     </script>
 
-    <link rel="icon" href="ROOT/media/images/favicon.ico" type="image/x-icon" sizes="16x16 32x32 48x48 256x256">
-    <link rel="icon" type="image/png" href="ROOT/media/images/favicon-16x16.png" sizes="16x16">
-    <link rel="icon" type="image/png" href="ROOT/media/images/favicon-32x32.png" sizes="32x32">
-    <link rel="icon" type="image/png" href="ROOT/media/images/favicon-96x96.png" sizes="96x96">
-    <link rel="apple-touch-icon" sizes="152x152" href="ROOT/media/images/apple-touch-icon-152x152.png">
+<link rel="icon" href="ROOT/_media/images/favicon.ico" type="image/x-icon" sizes="16x16 32x32 48x48 256x256">
+    <link rel="icon" type="image/png" href="ROOT/_media/images/favicon-16x16.png" sizes="16x16">
+    <link rel="icon" type="image/png" href="ROOT/_media/images/favicon-32x32.png" sizes="32x32">
+    <link rel="icon" type="image/png" href="ROOT/_media/images/favicon-96x96.png" sizes="96x96">
+    <link rel="apple-touch-icon" sizes="152x152" href="ROOT/_media/images/apple-touch-icon-152x152.png">
 
     <!-- Styles -->
     <?php if (file_exists(DOCROOT . $merged_css)): ?>
-    <link href="ROOT/<?= Enc::html($merged_css); ?>" rel="stylesheet" type="text/css">
+    <link href="ROOT/<?php echo Enc::html($merged_css); ?>" rel="stylesheet" type="text/css">
     <?php else: ?>
-    <link href="ROOT/media/css/normalize.css" rel="stylesheet" type="text/css">
-    <link href="ROOT/media/css/common.css" rel="stylesheet" type="text/css">
-    <link href="ROOT/media/css/ui.core.css" rel="stylesheet" type="text/css">
-    <link href="ROOT/sprout/media/css/admin_layout.css" rel="stylesheet">
-    <link href="ROOT/sprout/media/css/admin_editing_area.css" rel="stylesheet">
-    <link href="ROOT/media/css/facebox.css" rel="stylesheet">
+    <?php echo Media::tag('core/normalize.css') ?>
+    <?php echo Media::tag('core/common.css') ?>
+    <?php echo Media::tag('core/ui.core.css') ?>
+    <?php echo Media::tag('sprout/admin_layout.css') ?>
+    <?php echo Media::tag('sprout/admin_editing_area.css') ?>
+    <?php echo Media::tag('core/facebox.css') ?>
     <?php endif; ?>
 
     <!-- jQuery + jQuery UI -->
@@ -64,15 +64,15 @@ $merged_css = 'media/merged/admin.' . Sprout::getVersion() . '.css';
 
     <!-- Libraries -->
     <?php if (file_exists(DOCROOT . $merged_js)): ?>
-    <script src="ROOT/<?= Enc::html($merged_js); ?>"></script>
+    <script src="ROOT/<?php echo Enc::html($merged_js); ?>"></script>
     <?php else: ?>
-    <script src="ROOT/media/js/jquery.cookie.js"></script>
-    <script src="ROOT/media/js/common.js"></script>
-    <script src="/media/js/jquery.matchHeight-min.js"></script>
-    <script src="ROOT/sprout/media/js/admin_layout.js"></script>
-    <script src="ROOT/sprout/media/js/admin_editing_area.js"></script>
-    <script src="ROOT/media/js/facebox.js"></script>
-    <script src="ROOT/media/js/login.js"></script>
+    <?php echo Media::tag('core/jquery.cookie.js') ?>
+    <?php echo Media::tag('core/common.js') ?>
+    <?php echo Media::tag('core/jquery.matchHeight-min.js') ?>
+    <?php echo Media::tag('sprout/admin_layout.js') ?>
+    <?php echo Media::tag('sprout/admin_editing_area.js') ?>
+    <?php echo Media::tag('core/facebox.js') ?>
+    <?php echo Media::tag('core/login.js') ?>
     <?php endif; ?>
 
     <needs />

--- a/src/sprout/views/admin/main_layout.php
+++ b/src/sprout/views/admin/main_layout.php
@@ -19,11 +19,11 @@ use Sprout\Helpers\AdminPerms;
 use Sprout\Helpers\Csrf;
 use Sprout\Helpers\Enc;
 use Sprout\Helpers\Jquery;
+use Sprout\Helpers\Media;
 use Sprout\Helpers\Notification;
 use Sprout\Helpers\Router;
 use Sprout\Helpers\Sprout;
 use Sprout\Helpers\Subsites;
-
 
 $merged_js = 'media/merged/admin.' . Sprout::getVersion() . '.js';
 $merged_css = 'media/merged/admin.' . Sprout::getVersion() . '.css';
@@ -64,22 +64,22 @@ if (!$nav and !$nav_tools) {
     echo '<script>var csrfToken = "', Csrf::getTokenValue(), '";</script>', "\n";
     ?>
 
-    <link rel="icon" href="ROOT/media/images/favicon.ico" type="image/x-icon" sizes="16x16 32x32 48x48 256x256">
-    <link rel="icon" type="image/png" href="ROOT/media/images/favicon-16x16.png" sizes="16x16">
-    <link rel="icon" type="image/png" href="ROOT/media/images/favicon-32x32.png" sizes="32x32">
-    <link rel="icon" type="image/png" href="ROOT/media/images/favicon-96x96.png" sizes="96x96">
-    <link rel="apple-touch-icon" sizes="152x152" href="ROOT/media/images/apple-touch-icon-152x152.png">
+    <link rel="icon" href="ROOT/_media/images/favicon.ico" type="image/x-icon" sizes="16x16 32x32 48x48 256x256">
+    <link rel="icon" type="image/png" href="ROOT/_media/images/favicon-16x16.png" sizes="16x16">
+    <link rel="icon" type="image/png" href="ROOT/_media/images/favicon-32x32.png" sizes="32x32">
+    <link rel="icon" type="image/png" href="ROOT/_media/images/favicon-96x96.png" sizes="96x96">
+    <link rel="apple-touch-icon" sizes="152x152" href="ROOT/_media/images/apple-touch-icon-152x152.png">
 
     <!-- Styles -->
     <?php if (file_exists(DOCROOT . $merged_css)): ?>
-    <link href="ROOT/<?php echo $merged_css; ?>" rel="stylesheet" type="text/css">
+    <link href="ROOT/<?php echo Enc::html($merged_css); ?>" rel="stylesheet" type="text/css">
     <?php else: ?>
-    <link href="ROOT/media/css/normalize.css" rel="stylesheet" type="text/css">
-    <link href="ROOT/media/css/common.css" rel="stylesheet" type="text/css">
-    <link href="ROOT/media/css/ui.core.css" rel="stylesheet" type="text/css">
-    <link href="ROOT/sprout/media/css/admin_layout.css" rel="stylesheet">
-    <link href="ROOT/sprout/media/css/admin_editing_area.css" rel="stylesheet">
-    <link href="ROOT/media/css/facebox.css" rel="stylesheet">
+    <?php echo Media::tag('core/normalize.css') ?>
+    <?php echo Media::tag('core/common.css') ?>
+    <?php echo Media::tag('core/ui.core.css') ?>
+    <?php echo Media::tag('sprout/admin_layout.css') ?>
+    <?php echo Media::tag('sprout/admin_editing_area.css') ?>
+    <?php echo Media::tag('core/facebox.css') ?>
     <?php endif; ?>
 
     <!-- jQuery + jQuery UI -->
@@ -88,14 +88,14 @@ if (!$nav and !$nav_tools) {
 
     <!-- Libraries -->
     <?php if (file_exists(DOCROOT . $merged_js)): ?>
-    <script src="ROOT/<?php echo $merged_js; ?>"></script>
+    <script src="ROOT/<?php echo Enc::html($merged_js); ?>"></script>
     <?php else: ?>
-    <script src="ROOT/media/js/jquery.cookie.js"></script>
-    <script src="ROOT/media/js/common.js"></script>
-    <script src="ROOT/media/js/jquery.matchHeight-min.js"></script>
-    <script src="ROOT/sprout/media/js/admin_layout.js"></script>
-    <script src="ROOT/sprout/media/js/admin_editing_area.js"></script>
-    <script src="ROOT/media/js/facebox.js"></script>
+    <?php echo Media::tag('core/jquery.cookie.js') ?>
+    <?php echo Media::tag('core/common.js') ?>
+    <?php echo Media::tag('core/jquery.matchHeight-min.js') ?>
+    <?php echo Media::tag('sprout/admin_layout.js') ?>
+    <?php echo Media::tag('sprout/admin_editing_area.js') ?>
+    <?php echo Media::tag('core/facebox.js') ?>
     <?php endif; ?>
 
     <needs />


### PR DESCRIPTION
Lovely little cachebusting fixes.

This is two things really:

1. A helper for media resources so we're not string-hacking paths and URLs all the time.
2. Cachebusting for admin resources so browser/proxy caching doesn't break on deploy.