### PR TITLE
Feat/debug things

### DIFF
--- a/src/sprout/Helpers/BaseView.php
+++ b/src/sprout/Helpers/BaseView.php
@@ -26,6 +26,8 @@ use Sprout\Exceptions\FileMissingException;
 abstract class BaseView
 {
 
+    public static $DEBUG_COMMENT = !IN_PRODUCTION;
+
     protected static $EXTENSION = '.html';
 
     // The view file name and type
@@ -205,6 +207,34 @@ abstract class BaseView
         $default = null;
         return $default;
     }
+
+
+    /**
+     * A debug comment indicates where this view is being loaded.
+     *
+     * This is injected into the rendered output. It's only enabled given the
+     * static `DEBUG_COMMENT` property - default matches `IN_PRODUCTION`.
+     *
+     * This only appears in HTML/XML output.
+     *
+     * @return string
+     */
+    public function getDebugComment(): string
+    {
+        if (!static::$DEBUG_COMMENT) return '';
+
+        $filename = str_replace(DOCROOT, '', $this->kohana_filename);
+        $headers = headers_list();
+
+        foreach ($headers as $header) {
+            if (preg_match('/content-type:.*(html|xml)/i', $header)) {
+                return "<!-- {$filename} -->";
+            }
+        }
+
+        return '';
+    }
+
 
     /**
      * Magically converts view object to string.

--- a/src/sprout/Helpers/BaseView.php
+++ b/src/sprout/Helpers/BaseView.php
@@ -249,6 +249,7 @@ abstract class BaseView
         }
         catch (Exception $e)
         {
+            Kohana::logException($e, false);
             // Display the exception using its internal __toString method
             return (string) $e;
         }

--- a/src/sprout/Helpers/PhpView.php
+++ b/src/sprout/Helpers/PhpView.php
@@ -66,7 +66,9 @@ class PhpView extends BaseView
 
             return ob_get_clean();
         };
-        $output = $data_into_view($this->kohana_filename, $data);
+
+        $output = $this->getDebugComment();
+        $output .= $data_into_view($this->kohana_filename, $data);
 
         if ($renderer !== FALSE AND is_callable($renderer, TRUE))
         {

--- a/src/sprout/Helpers/TwigView.php
+++ b/src/sprout/Helpers/TwigView.php
@@ -86,7 +86,8 @@ class TwigView extends BaseView
             throw new Kohana_Exception('core.view_set_filename');
         }
 
-        $output = self::$twig->render($this->kohana_template_name, $this->kohana_local_data);
+        $output = $this->getDebugComment();
+        $output .= self::$twig->render($this->kohana_template_name, $this->kohana_local_data);
 
         if ($renderer !== FALSE AND is_callable($renderer, TRUE))
         {

--- a/src/sprout/core/Kohana.php
+++ b/src/sprout/core/Kohana.php
@@ -52,6 +52,9 @@ final class Kohana {
     // Will be set to TRUE when an exception is caught
     public static $has_error = FALSE;
 
+    // Enable or disable the fatal error handler
+    public static $enable_fatal_errors = TRUE;
+
     // The final output that will displayed by Kohana
     public static $output = '';
 
@@ -141,11 +144,13 @@ final class Kohana {
         // Set exception handler
         set_exception_handler(array('Kohana', 'exceptionHandler'));
 
-        // Catch fatal errors (compiler, memory, etc)
-        register_shutdown_function(array('Kohana', 'handleFatalErrors'));
+        if (self::$enable_fatal_errors) {
+            // Catch fatal errors (compiler, memory, etc)
+            register_shutdown_function(array('Kohana', 'handleFatalErrors'));
 
-        // Now switch off native errors because we've got our own now.
-        ini_set('display_errors', 0);
+            // Now switch off native errors because we've got our own now.
+            ini_set('display_errors', 0);
+        }
 
         // Send default text/html UTF-8 header
         header('Content-Type: text/html; charset=UTF-8');
@@ -706,17 +711,15 @@ final class Kohana {
      * are not reported by the error handler. Instead they are caught during
      * the shutdown event.
      *
-     * Register this with:
-     *
-     * ```
-     * register_shutdown_function([Kohana::class, 'handleFatalErrors']);
-     * ```
+     * Enable/disable this with the `$enable_fatal_errors` static prop.
      *
      * @return void
      * @throws ErrorException
      */
     public static function handleFatalErrors()
     {
+        if (!self::$enable_fatal_errors) return;
+
         $error = error_get_last();
 
         if ($error and $error['type'] & error_reporting()) {

--- a/src/sprout/core/Kohana.php
+++ b/src/sprout/core/Kohana.php
@@ -699,6 +699,22 @@ final class Kohana {
     }
 
 
+    /**
+     * Convert fatal errors to error exceptions.
+     *
+     * This is much like the error->exception helper above but fatal errors
+     * are not reported by the error handler. Instead they are caught during
+     * the shutdown event.
+     *
+     * Register this with:
+     *
+     * ```
+     * register_shutdown_function([Kohana::class, 'handleFatalErrors']);
+     * ```
+     *
+     * @return void
+     * @throws ErrorException
+     */
     public static function handleFatalErrors()
     {
         $error = error_get_last();


### PR DESCRIPTION
When inspecting a page we often tack on a `<!-- path/to/template -->` comment to help us find our way around. So this does it automatically (within non-production) for each view render.

This PR also has a fatal error handler. It's not something we see a lot of, but it makes prettier error pages of compiling or input errors. 

I probably want this in the v3.3 release but I'm twitchy about it for some reason. Any thoughts?