### PR TITLE
Adding support for other img locations in chunked upload

### DIFF
--- a/src/sprout/Helpers/Fb.php
+++ b/src/sprout/Helpers/Fb.php
@@ -503,6 +503,7 @@ class Fb
         if ($max_files < 1) $max_files = 1;
 
         $default_opts = [
+            'file_url' => null,
             'begin_url' => 'file_upload/upload_begin',
             'form_url' => 'file_upload/upload_form',
             'chunk_url' => 'file_upload/upload_chunk',
@@ -585,7 +586,7 @@ class Fb
 
             // Existing file stored on disk
             } else if ($file) {
-                $temp_path = WEBROOT . 'files/' . $file;
+                $temp_path = $opts['file_url'] ?? WEBROOT . 'files/' . $file;
                 $view = new PhpView('sprout/file_confirm');
                 $view->orig_file = ['name' => 'Existing file', 'size' => @filesize($temp_path)];
                 $type = File::getType($temp_path);


### PR DESCRIPTION
A simple change that allows an optional image source override to be applied for the chunked uploader.

This allows us to pull data from other locations (e.g. private/secure file systems) for display in the preview.

This is achieved by providing an $opts array, with the key `file_url` pointing to the desired image.

This is tested and working on a client site.