### PR TITLE
Fix/recursive file exports

### DIFF
--- a/src/sprout/Controllers/DbToolsController.php
+++ b/src/sprout/Controllers/DbToolsController.php
@@ -1393,9 +1393,18 @@ class DbToolsController extends Controller
     **/
     public function exportFiles()
     {
-        $files = File::glob('*');
+        $files = File::glob('*', 5);
+        $files = array_filter($files, fn($file) => !str_starts_with($file, 'resize/'));
 
         echo "<p>Found " . count($files) . " files.\n";
+
+        if ($_GET['debug'] ?? false) {
+            echo "<ul>\n";
+            foreach ($files as $file) {
+                echo '<li>', $file, "\n";
+            }
+            echo '</ul>';
+        }
 
         echo '<p>NOTE: Exports of many files may take a long time and/or fail.</p>';
 
@@ -1415,7 +1424,8 @@ class DbToolsController extends Controller
     {
         Csrf::checkOrDie();
 
-        $files = File::glob('*');
+        $files = File::glob('*', 5);
+        $files = array_filter($files, fn($file) => !str_starts_with($file, 'resize/'));
 
         echo "<p>Found " . count($files) . " files.\n";
 

--- a/src/sprout/Controllers/DbToolsController.php
+++ b/src/sprout/Controllers/DbToolsController.php
@@ -1401,7 +1401,7 @@ class DbToolsController extends Controller
         if ($_GET['debug'] ?? false) {
             echo "<ul>\n";
             foreach ($files as $file) {
-                echo '<li>', $file, "\n";
+                echo '<li>', Enc::html($file), "\n";
             }
             echo '</ul>';
         }

--- a/src/sprout/Helpers/File.php
+++ b/src/sprout/Helpers/File.php
@@ -420,10 +420,11 @@ class File
     * I have a feeling this returns other sizes (e.g. .small) as well - which may not be ideal.
     *
     * @param string $mask Files to find. Supports wildcards such as * and ?
+    * @param int $depth How deep to recursively search subdirectories, 0 to disable
     **/
-    public static function glob($mask)
+    public static function glob($mask, $depth = 0)
     {
-        return self::backend()->glob($mask);
+        return self::backend()->glob($mask, $depth);
     }
 
 

--- a/src/sprout/Helpers/FilesBackend.php
+++ b/src/sprout/Helpers/FilesBackend.php
@@ -81,7 +81,7 @@ abstract class FilesBackend {
     * Returns all files which match the specified mask.
     * I have a feeling this returns other sizes (e.g. .small) as well - which may not be ideal.
     **/
-    abstract function glob($mask);
+    abstract function glob($mask, $depth = 0);
 
 
     /**

--- a/src/sprout/Helpers/FilesBackendDirectory.php
+++ b/src/sprout/Helpers/FilesBackendDirectory.php
@@ -169,13 +169,34 @@ class FilesBackendDirectory extends FilesBackend
     * Returns all files which match the specified mask.
     * I have a feeling this returns other sizes (e.g. .small) as well - which may not be ideal.
     **/
-    public function glob($mask)
+    public function glob($mask, $depth = 0)
     {
-        $result = glob(WEBROOT . 'files/' . $mask);
-        foreach ($result as &$res) {
-            $res = basename($res);
-        }
-        return $result;
+        $output = [];
+
+        // A ref for the recursive function.
+        $find = null;
+
+        $find = function($base, $depth) use (&$find, &$output, $mask) {
+            $files = glob(WEBROOT . 'files/' . $base . $mask);
+
+            foreach ($files as $file) {
+                // Found one.
+                if (is_file($file)) {
+                    $output[] = $base . basename($file);
+                    continue;
+                }
+
+                // Dive in.
+                if ($depth > 0 and is_dir($file)) {
+                    $find($base . basename($file) . '/', $depth - 1);
+                }
+            }
+        };
+
+        // Start.
+        $find('', $depth);
+
+        return $output;
     }
 
 


### PR DESCRIPTION
Since adding support for nested files the exports tool doesn't work any more.

`glob(*)` doesn't naturally perform recursive searches, so this PR fixes that as well as the exports tool itself. This should be backwards compatible because the default recursion depth is 0 so it'll behave as usual.

@jamiemonksuk I know this will likely conflict with your multi-backend PR.