### PR TITLE
Feat/ai import tooling

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,10 @@
     "license": "GPL-2.0-or-later",
     "config": {
         "optimize-autoloader": true,
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "php-http/discovery": true
+        }
     },
     "autoload": {
         "psr-4": {
@@ -34,10 +37,13 @@
         "karmabunny/rdb": "^1.17",
         "karmabunny/router": "^2.7.12",
         "karmabunny/visor": "^1.0",
+        "nyholm/psr7": "^1.6",
+        "openai-php/client": "^0.4.1",
         "phpmailer/phpmailer": "^6.5",
         "psr/http-message": "^1.0",
         "setasign/fpdi": "^2.3",
         "setasign/tfpdf": "^1.32",
+        "symfony/http-client": "^6.3",
         "symfony/polyfill-php80": "^1.26",
         "symfony/polyfill-php81": "^1.26",
         "twig/twig": "^3.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "de8d3fa7396adbdb15f03dea70aa6d2a",
+    "content-hash": "73ea4489ad860eaaf1a50150a2fd2ae0",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -464,6 +464,363 @@
             "time": "2023-01-30T00:55:14+00:00"
         },
         {
+            "name": "nyholm/psr7",
+            "version": "1.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Nyholm/psr7.git",
+                "reference": "e874c8c4286a1e010fb4f385f3a55ac56a05cc93"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Nyholm/psr7/zipball/e874c8c4286a1e010fb4f385f3a55ac56a05cc93",
+                "reference": "e874c8c4286a1e010fb4f385f3a55ac56a05cc93",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1",
+                "php-http/message-factory": "^1.0",
+                "psr/http-factory": "^1.0",
+                "psr/http-message": "^1.0"
+            },
+            "provide": {
+                "php-http/message-factory-implementation": "1.0",
+                "psr/http-factory-implementation": "1.0",
+                "psr/http-message-implementation": "1.0"
+            },
+            "require-dev": {
+                "http-interop/http-factory-tests": "^0.9",
+                "php-http/psr7-integration-tests": "^1.0",
+                "phpunit/phpunit": "^7.5 || 8.5 || 9.4",
+                "symfony/error-handler": "^4.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Nyholm\\Psr7\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com"
+                },
+                {
+                    "name": "Martijn van der Ven",
+                    "email": "martijn@vanderven.se"
+                }
+            ],
+            "description": "A fast PHP7 implementation of PSR-7",
+            "homepage": "https://tnyholm.se",
+            "keywords": [
+                "psr-17",
+                "psr-7"
+            ],
+            "support": {
+                "issues": "https://github.com/Nyholm/psr7/issues",
+                "source": "https://github.com/Nyholm/psr7/tree/1.6.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Zegnat",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nyholm",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-04-17T16:03:48+00:00"
+        },
+        {
+            "name": "openai-php/client",
+            "version": "v0.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/openai-php/client.git",
+                "reference": "b16dbad9ac6507f7d9a3ec365b906f659e50e2b9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/openai-php/client/zipball/b16dbad9ac6507f7d9a3ec365b906f659e50e2b9",
+                "reference": "b16dbad9ac6507f7d9a3ec365b906f659e50e2b9",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1.0",
+                "php-http/discovery": "^1.15.2",
+                "php-http/multipart-stream-builder": "^1.2.0",
+                "psr/http-client": "^1.0.1",
+                "psr/http-client-implementation": "^1.0.1",
+                "psr/http-factory-implementation": "*",
+                "psr/http-message": "^1.0.1"
+            },
+            "require-dev": {
+                "guzzlehttp/guzzle": "^7.5.0",
+                "laravel/pint": "^1.7.0",
+                "nunomaduro/collision": "^7.3.3",
+                "pestphp/pest": "^2.2.3",
+                "pestphp/pest-plugin-arch": "^2.0.2",
+                "pestphp/pest-plugin-mock": "^2.0.0",
+                "phpstan/phpstan": "^1.10.8",
+                "rector/rector": "^0.14.8",
+                "symfony/var-dumper": "^6.2.7"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/OpenAI.php"
+                ],
+                "psr-4": {
+                    "OpenAI\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nuno Maduro",
+                    "email": "enunomaduro@gmail.com"
+                },
+                {
+                    "name": "Sandro Gehri"
+                }
+            ],
+            "description": "OpenAI PHP is a supercharged PHP API client that allows you to interact with the Open AI API",
+            "keywords": [
+                "GPT-3",
+                "api",
+                "client",
+                "codex",
+                "dall-e",
+                "language",
+                "natural",
+                "openai",
+                "php",
+                "processing",
+                "sdk"
+            ],
+            "support": {
+                "issues": "https://github.com/openai-php/client/issues",
+                "source": "https://github.com/openai-php/client/tree/v0.4.1"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/paypalme/enunomaduro",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/gehrisandro",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nunomaduro",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-03-24T11:41:32+00:00"
+        },
+        {
+            "name": "php-http/discovery",
+            "version": "1.19.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/discovery.git",
+                "reference": "57f3de01d32085fea20865f9b16fb0e69347c39e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/discovery/zipball/57f3de01d32085fea20865f9b16fb0e69347c39e",
+                "reference": "57f3de01d32085fea20865f9b16fb0e69347c39e",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0|^2.0",
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "nyholm/psr7": "<1.0",
+                "zendframework/zend-diactoros": "*"
+            },
+            "provide": {
+                "php-http/async-client-implementation": "*",
+                "php-http/client-implementation": "*",
+                "psr/http-client-implementation": "*",
+                "psr/http-factory-implementation": "*",
+                "psr/http-message-implementation": "*"
+            },
+            "require-dev": {
+                "composer/composer": "^1.0.2|^2.0",
+                "graham-campbell/phpspec-skip-example-extension": "^5.0",
+                "php-http/httplug": "^1.0 || ^2.0",
+                "php-http/message-factory": "^1.0",
+                "phpspec/phpspec": "^5.1 || ^6.1 || ^7.3",
+                "symfony/phpunit-bridge": "^6.2"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Http\\Discovery\\Composer\\Plugin",
+                "plugin-optional": true
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\Discovery\\": "src/"
+                },
+                "exclude-from-classmap": [
+                    "src/Composer/Plugin.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                }
+            ],
+            "description": "Finds and installs PSR-7, PSR-17, PSR-18 and HTTPlug implementations",
+            "homepage": "http://php-http.org",
+            "keywords": [
+                "adapter",
+                "client",
+                "discovery",
+                "factory",
+                "http",
+                "message",
+                "psr17",
+                "psr7"
+            ],
+            "support": {
+                "issues": "https://github.com/php-http/discovery/issues",
+                "source": "https://github.com/php-http/discovery/tree/1.19.1"
+            },
+            "time": "2023-07-11T07:02:26+00:00"
+        },
+        {
+            "name": "php-http/message-factory",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/message-factory.git",
+                "reference": "4d8778e1c7d405cbb471574821c1ff5b68cc8f57"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/message-factory/zipball/4d8778e1c7d405cbb471574821c1ff5b68cc8f57",
+                "reference": "4d8778e1c7d405cbb471574821c1ff5b68cc8f57",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                }
+            ],
+            "description": "Factory interfaces for PSR-7 HTTP Message",
+            "homepage": "http://php-http.org",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "stream",
+                "uri"
+            ],
+            "support": {
+                "issues": "https://github.com/php-http/message-factory/issues",
+                "source": "https://github.com/php-http/message-factory/tree/1.1.0"
+            },
+            "abandoned": "psr/http-factory",
+            "time": "2023-04-14T14:16:17+00:00"
+        },
+        {
+            "name": "php-http/multipart-stream-builder",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/multipart-stream-builder.git",
+                "reference": "f5938fd135d9fa442cc297dc98481805acfe2b6a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/multipart-stream-builder/zipball/f5938fd135d9fa442cc297dc98481805acfe2b6a",
+                "reference": "f5938fd135d9fa442cc297dc98481805acfe2b6a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0",
+                "php-http/discovery": "^1.15",
+                "psr/http-factory-implementation": "^1.0"
+            },
+            "require-dev": {
+                "nyholm/psr7": "^1.0",
+                "php-http/message": "^1.5",
+                "php-http/message-factory": "^1.0.2",
+                "phpunit/phpunit": "^7.5.15 || ^8.5 || ^9.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Http\\Message\\MultipartStream\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com"
+                }
+            ],
+            "description": "A builder class that help you create a multipart stream",
+            "homepage": "http://php-http.org",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "multipart stream",
+                "stream"
+            ],
+            "support": {
+                "issues": "https://github.com/php-http/multipart-stream-builder/issues",
+                "source": "https://github.com/php-http/multipart-stream-builder/tree/1.3.0"
+            },
+            "time": "2023-04-28T14:10:22+00:00"
+        },
+        {
             "name": "phpmailer/phpmailer",
             "version": "v6.7.1",
             "source": {
@@ -685,6 +1042,166 @@
             "time": "2022-01-05T17:46:08+00:00"
         },
         {
+            "name": "psr/container",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/container/issues",
+                "source": "https://github.com/php-fig/container/tree/2.0.2"
+            },
+            "time": "2021-11-05T16:47:00+00:00"
+        },
+        {
+            "name": "psr/http-client",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-client.git",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/bb5906edc1c324c9a05aa0873d40117941e5fa90",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP clients",
+            "homepage": "https://github.com/php-fig/http-client",
+            "keywords": [
+                "http",
+                "http-client",
+                "psr",
+                "psr-18"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-client"
+            },
+            "time": "2023-09-23T14:17:50+00:00"
+        },
+        {
+            "name": "psr/http-factory",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-factory.git",
+                "reference": "e616d01114759c4c489f93b099585439f795fe35"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/e616d01114759c4c489f93b099585439f795fe35",
+                "reference": "e616d01114759c4c489f93b099585439f795fe35",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0.0",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for PSR-7 HTTP message factories",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "psr",
+                "psr-17",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-factory/tree/1.0.2"
+            },
+            "time": "2023-04-10T20:10:41+00:00"
+        },
+        {
             "name": "psr/http-message",
             "version": "1.0.1",
             "source": {
@@ -736,6 +1253,56 @@
                 "source": "https://github.com/php-fig/http-message/tree/master"
             },
             "time": "2016-08-06T14:39:51+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/fe5ea303b0887d5caefd3d431c3e61ad47037001",
+                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/3.0.0"
+            },
+            "time": "2021-07-14T16:46:02+00:00"
         },
         {
             "name": "setasign/fpdi",
@@ -862,6 +1429,243 @@
                 "source": "https://github.com/Setasign/tFPDF/tree/v1.33"
             },
             "time": "2022-12-20T10:26:07+00:00"
+        },
+        {
+            "name": "symfony/deprecation-contracts",
+            "version": "v3.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "7c3aff79d10325257a001fcf92d991f24fc967cf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/7c3aff79d10325257a001fcf92d991f24fc967cf",
+                "reference": "7c3aff79d10325257a001fcf92d991f24fc967cf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.4-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-05-23T14:45:45+00:00"
+        },
+        {
+            "name": "symfony/http-client",
+            "version": "v6.3.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/http-client.git",
+                "reference": "0314e2d49939a9831929d6fc81c01c6df137fd0a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/http-client/zipball/0314e2d49939a9831929d6fc81c01c6df137fd0a",
+                "reference": "0314e2d49939a9831929d6fc81c01c6df137fd0a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/log": "^1|^2|^3",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/http-client-contracts": "^3",
+                "symfony/service-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "php-http/discovery": "<1.15",
+                "symfony/http-foundation": "<6.3"
+            },
+            "provide": {
+                "php-http/async-client-implementation": "*",
+                "php-http/client-implementation": "*",
+                "psr/http-client-implementation": "1.0",
+                "symfony/http-client-implementation": "3.0"
+            },
+            "require-dev": {
+                "amphp/amp": "^2.5",
+                "amphp/http-client": "^4.2.1",
+                "amphp/http-tunnel": "^1.0",
+                "amphp/socket": "^1.1",
+                "guzzlehttp/promises": "^1.4",
+                "nyholm/psr7": "^1.0",
+                "php-http/httplug": "^1.0|^2.0",
+                "psr/http-client": "^1.0",
+                "symfony/dependency-injection": "^5.4|^6.0",
+                "symfony/http-kernel": "^5.4|^6.0",
+                "symfony/process": "^5.4|^6.0",
+                "symfony/stopwatch": "^5.4|^6.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\HttpClient\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides powerful methods to fetch HTTP resources synchronously or asynchronously",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "http"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/http-client/tree/v6.3.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-11-06T18:31:59+00:00"
+        },
+        {
+            "name": "symfony/http-client-contracts",
+            "version": "v3.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/http-client-contracts.git",
+                "reference": "1ee70e699b41909c209a0c930f11034b93578654"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/1ee70e699b41909c209a0c930f11034b93578654",
+                "reference": "1ee70e699b41909c209a0c930f11034b93578654",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.4-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\HttpClient\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Test/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to HTTP clients",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/http-client-contracts/tree/v3.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-07-30T20:28:31+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -1268,6 +2072,88 @@
                 }
             ],
             "time": "2023-01-26T09:26:14+00:00"
+        },
+        {
+            "name": "symfony/service-contracts",
+            "version": "v3.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/service-contracts.git",
+                "reference": "b3313c2dbffaf71c8de2934e2ea56ed2291a3838"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/b3313c2dbffaf71c8de2934e2ea56ed2291a3838",
+                "reference": "b3313c2dbffaf71c8de2934e2ea56ed2291a3838",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/container": "^2.0"
+            },
+            "conflict": {
+                "ext-psr": "<1.1|>=2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.4-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Service\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Test/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to writing services",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/service-contracts/tree/v3.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-07-30T20:28:31+00:00"
         },
         {
             "name": "twig/twig",

--- a/src/sprout/Controllers/Admin/HasCategoriesAdminController.php
+++ b/src/sprout/Controllers/Admin/HasCategoriesAdminController.php
@@ -498,7 +498,9 @@ abstract class HasCategoriesAdminController extends ManagedAdminController {
     * @param array $new_data The new data of the record.
     * @param array $existing_record The old data of the record, which has now been replaced.
     * @param string $type One of 'insert' or 'update'.
-    * @param boolean False if any errors are encountered; will cancel the entire import process.
+    * @param array $raw_data Raw CSV data, with original field names.
+
+    * @return boolean False if any errors are encountered; will cancel the entire import process.
     **/
     protected function _importPostRecord($record_id, $new_data, $existing_record, $type, $raw_data)
     {

--- a/src/sprout/Controllers/DbToolsController.php
+++ b/src/sprout/Controllers/DbToolsController.php
@@ -29,6 +29,7 @@ use karmabunny\pdb\Exceptions\QueryException;
 use karmabunny\pdb\Exceptions\RowMissingException;
 use karmabunny\pdb\PdbParser;
 use Sprout\Exceptions\ValidationException;
+use Sprout\Exceptions\WorkerJobException;
 use Sprout\Helpers\Admin;
 use Sprout\Helpers\AdminAuth;
 use Sprout\Helpers\Archive;
@@ -81,6 +82,8 @@ use Sprout\Helpers\Url;
 use Sprout\Helpers\Validator;
 use Sprout\Helpers\Validity;
 use Sprout\Helpers\PhpView;
+use Sprout\Helpers\AI\OpenAiApi;
+use Sprout\Helpers\WorkerCtrl;
 use Sprout\Models\ExceptionLogModel;
 
 /**
@@ -114,6 +117,10 @@ class DbToolsController extends Controller
             [ 'url' => 'dbtools/moduleBuilderExisting', 'name' => 'Module builder from existing', 'desc' => 'Generates modules from an existing db_struct.xml file' ],
             [ 'url' => 'dbtools/multimake', 'name' => 'Generate multiedit', 'desc' => 'Generate multiedit code' ],
             [ 'url' => 'dbtools/modelGenerator', 'name' => 'Model Generator', 'desc' => 'Generate a model class from a table in db_struct.xml' ],
+        ],
+        'AI' => [
+            [ 'url' => 'dbtools/openAiTest', 'name' => 'Open AI Tester', 'desc' => 'Prompt tester for Open AI' ],
+            [ 'url' => 'dbtools/processAiContentQueue', 'name' => 'AI Content Queue Process', 'desc' => 'Worker to process items in AI content queue' ],
         ],
         'Environment' => [
             [ 'url' => 'dbtools/info', 'name' => 'Env and PHP info', 'desc' => 'Sprout information + phpinfo()' ],

--- a/src/sprout/Controllers/DbToolsController.php
+++ b/src/sprout/Controllers/DbToolsController.php
@@ -1487,7 +1487,11 @@ class DbToolsController extends Controller
     }
 
 
-
+    /**
+     * Pass a request to Open AI API and render out the result accordingly
+     *
+     * @return void
+     */
     public function openAiTestSubmit()
     {
         Csrf::checkOrDie();
@@ -1501,31 +1505,99 @@ class DbToolsController extends Controller
         }
 
         $response = OpenAiApi::$endpoint($_POST['prompt']);
+        $debug = $_POST['debug_data'];
 
         match ($endpoint) {
-            'chatCompletion' => $this->openAiTextOutput($response),
-            'imageGenerateSrc' => $this->openAiImageOutputSrc($response),
-            'imageGenerateBlob' => $this->openAiImageOutputBlob($response),
+            'chatCompletion' => $this->openAiTextOutput($response, $debug),
+            'imageGenerateSrc' => $this->openAiImageOutputSrc($response, $debug),
+            'imageGenerateBlob' => $this->openAiImageOutputBlob($response, $debug),
             default => throw new \Exception('Unsupported endpoint'),
         };
     }
 
 
-    public function openAiTextOutput($response)
+    /**
+     * Render out a text response
+     *
+     * @param string $response
+     *
+     * @return void
+     */
+    public function openAiTextOutput(string $response, string $debug): void
     {
         echo $response;
+        $this->openAiDebugOutput($debug);
     }
 
 
-    public function openAiImageOutputSrc($response)
+    /**
+     * Render out n image URL response
+     *
+     * @param string $response
+     *
+     * @return void
+     */
+    public function openAiImageOutputSrc(string $response, string $debug): void
     {
         echo '<img src="', $response, '" style="max-width: 100%">';
+        $this->openAiDebugOutput($debug);
     }
 
 
-    public function openAiImageOutputBlob($response)
+    /**
+     * Render out n image blob response
+     *
+     * @param string $response
+     *
+     * @return void
+     */
+    public function openAiImageOutputBlob(string $response, string $debug): void
     {
         echo "<img src=\"data:image/jpeg;base64,{$response}\" style=\"max-width: 100%\">";
+        $this->openAiDebugOutput($debug);
+    }
+
+
+    /**
+     * Render out the debug output based on the type requested
+     *
+     * @param string $debug
+     *
+     * @return void
+     */
+    public function openAiDebugOutput(string $debug)
+    {
+        match ($debug) {
+            'tokens' => $this->openAiLastTokensOutput(),
+            'debug' => $this->openAiLastRequestOutput(),
+            default => null,
+        };
+    }
+
+
+    /**
+     * Render out the last request made to Open AI
+     *
+     * @return void
+     */
+    public function openAiLastRequestOutput()
+    {
+        echo '<br><br><hr><br>';
+        $raw = OpenAiApi::getTokensUsed();
+        echo '<pre>', Enc::html(print_r($raw, true)), '</pre>';
+    }
+
+
+    /**
+     * Render out the tokens used in the last request
+     *
+     * @return void
+     */
+    public function openAiLastTokensOutput()
+    {
+        echo '<br><br><hr><br>';
+        $raw = OpenAiApi::getTokensUsed();
+        echo '<pre>', Enc::html(print_r($raw, true)), '</pre>';
     }
 
 

--- a/src/sprout/Controllers/DbToolsController.php
+++ b/src/sprout/Controllers/DbToolsController.php
@@ -1522,6 +1522,24 @@ class DbToolsController extends Controller
 
 
     /**
+     * Fire the job to process AI Content form the queue
+     *
+     * @return never
+     */
+    public function processAiContentQueue()
+    {
+        try {
+            $info = WorkerCtrl::start('Sprout\\Helpers\\AI\\WorkerAiContentProcess');
+        } catch (WorkerJobException $ex) {
+            Notification::error('Unable to create worker job');
+            Url::redirect('admin/intro/file');
+        }
+
+        Url::redirect($info['log_url']);
+    }
+
+
+    /**
     * Edit the $_SESSION
     **/
     public function sessionEditor()

--- a/src/sprout/Controllers/DbToolsController.php
+++ b/src/sprout/Controllers/DbToolsController.php
@@ -1505,6 +1505,8 @@ class DbToolsController extends Controller
         }
 
         $response = OpenAiApi::$endpoint($_POST['prompt']);
+
+        // Setting to output debug data ('', 'tokens' or 'debug')
         $debug = $_POST['debug_data'];
 
         match ($endpoint) {
@@ -1520,6 +1522,7 @@ class DbToolsController extends Controller
      * Render out a text response
      *
      * @param string $response
+     * @param string $debug Setting to output debug data ('', 'tokens' or 'debug')
      *
      * @return void
      */
@@ -1534,6 +1537,7 @@ class DbToolsController extends Controller
      * Render out n image URL response
      *
      * @param string $response
+     * @param string $debug Setting to output debug data ('', 'tokens' or 'debug')
      *
      * @return void
      */
@@ -1548,6 +1552,7 @@ class DbToolsController extends Controller
      * Render out n image blob response
      *
      * @param string $response
+     * @param string $debug Setting to output debug data ('', 'tokens' or 'debug')
      *
      * @return void
      */
@@ -1561,7 +1566,7 @@ class DbToolsController extends Controller
     /**
      * Render out the debug output based on the type requested
      *
-     * @param string $debug
+     * @param string $debug Setting to output debug data ('', 'tokens' or 'debug')
      *
      * @return void
      */

--- a/src/sprout/Controllers/DbToolsController.php
+++ b/src/sprout/Controllers/DbToolsController.php
@@ -1461,6 +1461,67 @@ class DbToolsController extends Controller
 
 
     /**
+    * Simple test tools for working out Open AI tooling using the client's keys
+    **/
+    public function openAiTest()
+    {
+        $key = Kohana::config('openai.secret_key');
+        if (empty($key)) {
+            echo '<p><em>OpenAI secret key not configured in config.openai.secret_key</em></p>';
+            $this->template('AI Tooling');
+            return;
+        }
+
+        $view = new PhpView('sprout/dbtools/openai_test');
+        echo $view->render();
+
+        $this->template('AI Tooling');
+    }
+
+
+
+    public function openAiTestSubmit()
+    {
+        Csrf::checkOrDie();
+
+        $endpoint = $_POST['endpoint'];
+
+        if (!method_exists('Sprout\\Helpers\\AI\\OpenAiApi', $endpoint)) {
+            $endpoint = Enc::html($endpoint);
+            echo "<p><em>Invalid endpoint: {$endpoint}</em></p>";
+            return;
+        }
+
+        $response = OpenAiApi::$endpoint($_POST['prompt']);
+
+        match ($endpoint) {
+            'chatCompletion' => $this->openAiTextOutput($response),
+            'imageGenerateSrc' => $this->openAiImageOutputSrc($response),
+            'imageGenerateBlob' => $this->openAiImageOutputBlob($response),
+            default => throw new \Exception('Unsupported endpoint'),
+        };
+    }
+
+
+    public function openAiTextOutput($response)
+    {
+        echo $response;
+    }
+
+
+    public function openAiImageOutputSrc($response)
+    {
+        echo '<img src="', $response, '" style="max-width: 100%">';
+    }
+
+
+    public function openAiImageOutputBlob($response)
+    {
+        echo "<img src=\"data:image/jpeg;base64,{$response}\" style=\"max-width: 100%\">";
+    }
+
+
+    /**
     * Edit the $_SESSION
     **/
     public function sessionEditor()

--- a/src/sprout/Controllers/DbToolsController.php
+++ b/src/sprout/Controllers/DbToolsController.php
@@ -120,7 +120,8 @@ class DbToolsController extends Controller
         ],
         'AI' => [
             [ 'url' => 'dbtools/openAiTest', 'name' => 'Open AI Tester', 'desc' => 'Prompt tester for Open AI' ],
-            [ 'url' => 'dbtools/processAiContentQueue', 'name' => 'AI Content Queue Process', 'desc' => 'Worker to process items in AI content queue' ],
+            [ 'url' => 'dbtools/processAiContentQueue', 'name' => 'Process AI Content Queue', 'desc' => 'Worker to process items in AI content queue' ],
+            [ 'url' => 'dbtools/processAiContentQueue?retry=1', 'name' => 'Retry AI Content Queue', 'desc' => 'Process AI content queue and retry any failed items' ],
         ],
         'Environment' => [
             [ 'url' => 'dbtools/info', 'name' => 'Env and PHP info', 'desc' => 'Sprout information + phpinfo()' ],
@@ -1535,8 +1536,10 @@ class DbToolsController extends Controller
      */
     public function processAiContentQueue()
     {
+        $retry_failed = $_GET['retry'] ?? 0;
+
         try {
-            $info = WorkerCtrl::start('Sprout\\Helpers\\AI\\WorkerAiContentProcess');
+            $info = WorkerCtrl::start('Sprout\\Helpers\\AI\\WorkerAiContentProcess', $retry_failed);
         } catch (WorkerJobException $ex) {
             Notification::error('Unable to create worker job');
             Url::redirect('admin/intro/file');

--- a/src/sprout/Controllers/DbToolsController.php
+++ b/src/sprout/Controllers/DbToolsController.php
@@ -1543,7 +1543,7 @@ class DbToolsController extends Controller
      */
     public function openAiImageOutputSrc(string $response, string $debug): void
     {
-        echo '<img src="', $response, '" style="max-width: 100%">';
+        echo '<img src="', Enc::html($response), '" style="max-width: 100%">';
         $this->openAiDebugOutput($debug);
     }
 
@@ -1558,6 +1558,12 @@ class DbToolsController extends Controller
      */
     public function openAiImageOutputBlob(string $response, string $debug): void
     {
+        // Validate the $response is base64
+        if (!preg_match('/^[a-zA-Z0-9\/\r\n+]*={0,2}$/', $response)) {
+            echo '<p><em>Invalid image response</em></p>';
+            return;
+        }
+
         echo "<img src=\"data:image/jpeg;base64,{$response}\" style=\"max-width: 100%\">";
         $this->openAiDebugOutput($debug);
     }

--- a/src/sprout/Helpers/AI/AI.php
+++ b/src/sprout/Helpers/AI/AI.php
@@ -1,0 +1,63 @@
+<?php
+namespace Sprout\Helpers\AI;
+
+use Exception;
+use Kohana;
+use Sprout\Helpers\AI\AiApiBase;
+use Sprout\Helpers\AI\OpenAiApi;
+
+
+/**
+ * General helpers for AI system
+ */
+class AI
+{
+
+    /**
+     * Available classes for AI.
+     *
+     * Core config ai.enabled_class should be one of these values
+     */
+    const AI_CLASSES = [
+        OpenAiApi::class => 'OpenAi',
+    ];
+
+
+    /**
+     * Check if AI usage is enabled (class configured and return enabled)?
+     *
+     * @return bool
+     */
+    public static function isEnabled(): bool
+    {
+        $enabled_class = Kohana::config('ai.enabled_class');
+        $class = array_search($enabled_class, self::AI_CLASSES);
+
+        if ($class === false) {
+            throw new Exception('Invalid AI class: ' . $enabled_class);
+        }
+
+        /** @var AiApiBase */
+        $class = new $class();
+
+        // Ask the class if it has everything it needs to run
+        return $class->getUsable();
+    }
+
+
+    /**
+     * Get a list of endpoint methods available for each AI class
+     *
+     * @return array
+     */
+    public static function classesAndMethod()
+    {
+        $out = [];
+        foreach (self::AI_CLASSES as $class => $name) {
+            $out[$class] = $class::ENDPOINTS;
+        }
+
+        return $out;
+    }
+
+}

--- a/src/sprout/Helpers/AI/AI.php
+++ b/src/sprout/Helpers/AI/AI.php
@@ -1,4 +1,15 @@
 <?php
+/*
+ * Copyright (C) 2023 Karmabunny Pty Ltd.
+ *
+ * This file is a part of SproutCMS.
+ *
+ * SproutCMS is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU General Public License as published by the Free Software Foundation, either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * For more information, visit <http://getsproutcms.com>.
+ */
 namespace Sprout\Helpers\AI;
 
 use Exception;

--- a/src/sprout/Helpers/AI/AI.php
+++ b/src/sprout/Helpers/AI/AI.php
@@ -16,7 +16,7 @@ use Exception;
 use Kohana;
 use Sprout\Helpers\AI\AiApiInterface;
 use Sprout\Helpers\AI\OpenAiApi;
-
+use Sprout\Helpers\Sprout;
 
 /**
  * General helpers for AI system
@@ -49,7 +49,7 @@ class AI
         }
 
         /** @var AiApiInterface */
-        $class = new $class();
+        $class = Sprout::instance($class);
 
         // Ask the class if it has everything it needs to run
         return $class->getUsable();

--- a/src/sprout/Helpers/AI/AI.php
+++ b/src/sprout/Helpers/AI/AI.php
@@ -14,7 +14,7 @@ namespace Sprout\Helpers\AI;
 
 use Exception;
 use Kohana;
-use Sprout\Helpers\AI\AiApiBase;
+use Sprout\Helpers\AI\AiApiInterface;
 use Sprout\Helpers\AI\OpenAiApi;
 
 
@@ -48,7 +48,7 @@ class AI
             throw new Exception('Invalid AI class: ' . $enabled_class);
         }
 
-        /** @var AiApiBase */
+        /** @var AiApiInterface */
         $class = new $class();
 
         // Ask the class if it has everything it needs to run

--- a/src/sprout/Helpers/AI/AiApiBase.php
+++ b/src/sprout/Helpers/AI/AiApiBase.php
@@ -1,4 +1,15 @@
 <?php
+/*
+ * Copyright (C) 2023 Karmabunny Pty Ltd.
+ *
+ * This file is a part of SproutCMS.
+ *
+ * SproutCMS is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU General Public License as published by the Free Software Foundation, either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * For more information, visit <http://getsproutcms.com>.
+ */
 namespace Sprout\Helpers\AI;
 
 /**

--- a/src/sprout/Helpers/AI/AiApiBase.php
+++ b/src/sprout/Helpers/AI/AiApiBase.php
@@ -1,0 +1,25 @@
+<?php
+namespace Sprout\Helpers\AI;
+
+/**
+ * Base class to ensure common functions for API tooling
+ */
+abstract class AiApiBase
+{
+
+    /**
+     * Get a list of endpoints available for use with this class
+     *
+     * @return array
+     */
+    abstract public function getEndpoints(): array;
+
+
+    /**
+     * Class specific check to see if we can use AI. E.g. do we have a key?
+     *
+     * @return bool
+     */
+    abstract public function getUsable(): bool;
+
+}

--- a/src/sprout/Helpers/AI/AiApiBase.php
+++ b/src/sprout/Helpers/AI/AiApiBase.php
@@ -22,4 +22,20 @@ abstract class AiApiBase
      */
     abstract public function getUsable(): bool;
 
+
+    /**
+     * Get the cost of the last request
+     *
+     * @return mixed
+     */
+    abstract public function getLastRequestCost(): mixed;
+
+
+    /**
+     * Describe what the cost unit is for this system (e.g. dollars, tokens)
+     *
+     * @return string
+     */
+    abstract public function getRequestCostUnit(): string;
+
 }

--- a/src/sprout/Helpers/AI/AiApiInterface.php
+++ b/src/sprout/Helpers/AI/AiApiInterface.php
@@ -15,7 +15,7 @@ namespace Sprout\Helpers\AI;
 /**
  * Base class to ensure common functions for API tooling
  */
-abstract class AiApiBase
+interface AiApiInterface
 {
 
     /**
@@ -23,7 +23,7 @@ abstract class AiApiBase
      *
      * @return array
      */
-    abstract public function getEndpoints(): array;
+    public function getEndpoints(): array;
 
 
     /**
@@ -31,7 +31,7 @@ abstract class AiApiBase
      *
      * @return bool
      */
-    abstract public function getUsable(): bool;
+    public function getUsable(): bool;
 
 
     /**
@@ -39,7 +39,7 @@ abstract class AiApiBase
      *
      * @return mixed
      */
-    abstract public function getLastRequestCost(): mixed;
+    public function getLastRequestCost(): mixed;
 
 
     /**
@@ -47,6 +47,6 @@ abstract class AiApiBase
      *
      * @return string
      */
-    abstract public function getRequestCostUnit(): string;
+    public function getRequestCostUnit(): string;
 
 }

--- a/src/sprout/Helpers/AI/OpenAiApi.php
+++ b/src/sprout/Helpers/AI/OpenAiApi.php
@@ -26,7 +26,7 @@ use OpenAI\Responses\Images\CreateResponse as ImageCreateResponse;
 /**
  * General helper tools for interacting with the OpenAI API
  */
-class OpenAiApi extends AiApiBase
+class OpenAiApi implements AiApiInterface
 {
 
     /** @var array */

--- a/src/sprout/Helpers/AI/OpenAiApi.php
+++ b/src/sprout/Helpers/AI/OpenAiApi.php
@@ -1,0 +1,152 @@
+<?php
+namespace Sprout\Helpers\AI;
+
+use Http\Discovery\Exception\NotFoundException;
+use Kohana;
+use Kohana_Exception;
+use OpenAI;
+use OpenAI\Exceptions\ErrorException;
+use OpenAI\Exceptions\InvalidArgumentException;
+use OpenAI\Exceptions\UnserializableResponse;
+use OpenAI\Exceptions\TransporterException;
+use OpenAI\Responses\Chat\CreateResponse as ChatCreateResponse;
+use OpenAI\Responses\Images\CreateResponse as ImageCreateResponse;
+
+/**
+ * General helper tools for interacting with the OpenAI API
+ */
+class OpenAiApi extends AiApiBase
+{
+
+    const ENDPOINTS = [
+        'chatCompletion' => 'Chat Completions',
+        'imageGenerateSrc' => 'Image Generation - External URL',
+        'imageGenerateBlob' => 'Image Generation - Image Data',
+    ];
+
+
+    /** @inheritdoc  */
+    public function getEndpoints(): array
+    {
+        return self::ENDPOINTS;
+    }
+
+
+    /** @inheritdoc  */
+    public function getUsable(): bool
+    {
+        $key = Kohana::config('openai.secret_key');
+        return !empty($key);
+    }
+
+
+    /**
+     *
+     * @param string|array $prompt
+     * @param array $config
+     *
+     * @return string|null
+     *
+     * @throws Kohana_Exception
+     * @throws NotFoundException
+     * @throws InvalidArgumentException
+     * @throws ErrorException
+     * @throws UnserializableResponse
+     * @throws TransporterException
+     */
+    public static function chatCompletion(string|array $prompt, array $config = []): ?string
+    {
+        if (!is_array($prompt)) {
+            $prompt = [[
+                'role' => 'user',
+                'content' => $prompt,
+            ]];
+        }
+        $data = [
+            'model' => $config['model'] ?? 'gpt-4',
+            'messages' => $prompt,
+            'max_tokens' => $config['max-tokens'] ?? 500,
+        ];
+
+        // Exceptions need catching by caller
+        $key = Kohana::config('openai.secret_key');
+        $client = OpenAI::client($key);
+
+        /** @var ChatCreateResponse */
+        $response = $client->chat()->create($data);
+
+        return $response['choices'][0]['message']['content'] ?? '';
+    }
+
+
+    /**
+     * Generate an image with Open AI and return a URL to the hosted file
+     *
+     * https://platform.openai.com/docs/api-reference/images/create
+     *
+     * @param string $prompt
+     * @param array $config
+     *
+     * @return string|null Image src URL
+     *
+     * @throws Kohana_Exception
+     * @throws NotFoundException
+     * @throws InvalidArgumentException
+     * @throws ErrorException
+     * @throws UnserializableResponse
+     * @throws TransporterException
+     */
+    public static function imageGenerateSrc(string $prompt, array $config = []): ?string
+    {
+        $data = [
+            'model' => $config['model'] ?? 'dall-e-2',
+            'prompt' => $prompt,
+            'response_format' => 'url',
+        ];
+
+        // Exceptions need catching by caller
+        $key = Kohana::config('openai.secret_key');
+        $client = OpenAI::client($key);
+
+        /** @var ImageCreateResponse */
+        $response = $client->images()->create($data);
+
+        return $response['data'][0]['url'] ?? null;
+    }
+
+
+    /**
+     * Generate an image with Open AI and return a blob of image data
+     *
+     * Output this with something like:
+     * echo "<img src=\"data:image/jpeg;base64,{$response}\" style=\"max-width: 100%\">";
+     *
+     * https://platform.openai.com/docs/api-reference/images/create
+     *
+     * @param string $prompt
+     * @param array $config
+     *
+     * @return string Image contents
+     */
+    public static function imageGenerateBlob(string $prompt, array $config = []): ?string
+    {
+        $data = [
+            'prompt' => $prompt,
+            'response_format' => 'b64_json',
+        ];
+
+        if (!empty($config['model'])) {
+            $data['model'] = $config['model'];
+        }
+
+        // Exceptions need catching by caller
+        $key = Kohana::config('openai.secret_key');
+        $client = OpenAI::client($key);
+
+        /** @var ImageCreateResponse */
+        $response = $client->images()->create($data);
+
+        return $response['data'][0]['b64_json'];
+    }
+
+}

--- a/src/sprout/Helpers/AI/OpenAiApi.php
+++ b/src/sprout/Helpers/AI/OpenAiApi.php
@@ -58,8 +58,8 @@ class OpenAiApi implements AiApiInterface
     /** @inheritdoc */
     public function getLastRequestCost(): mixed
     {
-        $response = self::$_last_response;
-        return $response['usage']['total_tokens'];
+        $tokens = self::getTokensUsed();
+        return $tokens['total_tokens'];
     }
 
 
@@ -91,7 +91,11 @@ class OpenAiApi implements AiApiInterface
     public static function getTokensUsed(): array
     {
         $response = self::$_last_response;
-        return $response['usage'];
+        return $response['usage'] ?? [
+            'completion_tokens' => 0,
+            'prompt_tokens' => 0,
+            'total_tokens' => 0,
+        ];
     }
 
 

--- a/src/sprout/Helpers/AI/OpenAiApi.php
+++ b/src/sprout/Helpers/AI/OpenAiApi.php
@@ -1,4 +1,15 @@
 <?php
+/*
+ * Copyright (C) 2023 Karmabunny Pty Ltd.
+ *
+ * This file is a part of SproutCMS.
+ *
+ * SproutCMS is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU General Public License as published by the Free Software Foundation, either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * For more information, visit <http://getsproutcms.com>.
+ */
 namespace Sprout\Helpers\AI;
 
 use Http\Discovery\Exception\NotFoundException;

--- a/src/sprout/Helpers/AI/OpenAiApi.php
+++ b/src/sprout/Helpers/AI/OpenAiApi.php
@@ -62,6 +62,12 @@ class OpenAiApi extends AiApiBase
                 'content' => $prompt,
             ]];
         }
+
+        // Optional default config load
+        if (empty($config)) {
+            $config = Kohana::config('openai.chat_completion') ?? [];
+        }
+
         $data = [
             'model' => $config['model'] ?? 'gpt-4',
             'messages' => $prompt,
@@ -98,6 +104,12 @@ class OpenAiApi extends AiApiBase
      */
     public static function imageGenerateSrc(string $prompt, array $config = []): ?string
     {
+
+        // Optional default config load
+        if (empty($config)) {
+            $config = Kohana::config('openai.chat_completion') ?? [];
+        }
+
         $data = [
             'model' => $config['model'] ?? 'dall-e-2',
             'prompt' => $prompt,
@@ -130,6 +142,12 @@ class OpenAiApi extends AiApiBase
      */
     public static function imageGenerateBlob(string $prompt, array $config = []): ?string
     {
+
+        // Optional default config load
+        if (empty($config)) {
+            $config = Kohana::config('openai.chat_completion') ?? [];
+        }
+
         $data = [
             'prompt' => $prompt,
             'response_format' => 'b64_json',

--- a/src/sprout/Helpers/AI/OpenAiApi.php
+++ b/src/sprout/Helpers/AI/OpenAiApi.php
@@ -18,6 +18,10 @@ use OpenAI\Responses\Images\CreateResponse as ImageCreateResponse;
 class OpenAiApi extends AiApiBase
 {
 
+    /** @var array */
+    private static $_last_response = [];
+
+
     const ENDPOINTS = [
         'chatCompletion' => 'Chat Completions',
         'imageGenerateSrc' => 'Image Generation - External URL',
@@ -37,6 +41,31 @@ class OpenAiApi extends AiApiBase
     {
         $key = Kohana::config('openai.secret_key');
         return !empty($key);
+    }
+
+
+    /**
+     * Get the last response from the API
+     *
+     * This can be used to extract token usage, finish reason or other data
+     *
+     * @return array
+     */
+    public static function getLastResponse(): array
+    {
+        return self::$_last_response;
+    }
+
+
+    /**
+     * Get the number of tokens used in the last request
+     *
+     * @return array [completion_tokens => int, prompt_tokens => int, total_tokens => int]
+     */
+    public static function getTokensUsed(): array
+    {
+        $response = self::$_last_response;
+        return $response['usage'];
     }
 
 
@@ -80,6 +109,10 @@ class OpenAiApi extends AiApiBase
 
         /** @var ChatCreateResponse */
         $response = $client->chat()->create($data);
+        $response = $response->toArray();
+
+        // Make the last response available for debugging
+        self::$_last_response = $response;
 
         return $response['choices'][0]['message']['content'] ?? '';
     }
@@ -122,6 +155,10 @@ class OpenAiApi extends AiApiBase
 
         /** @var ImageCreateResponse */
         $response = $client->images()->create($data);
+        $response = $response->toArray();
+
+        // Make the last response available for debugging
+        self::$_last_response = $response;
 
         return $response['data'][0]['url'] ?? null;
     }
@@ -163,6 +200,10 @@ class OpenAiApi extends AiApiBase
 
         /** @var ImageCreateResponse */
         $response = $client->images()->create($data);
+        $response = $response->toArray();
+
+        // Make the last response available for debugging
+        self::$_last_response = $response;
 
         return $response['data'][0]['b64_json'];
     }

--- a/src/sprout/Helpers/AI/OpenAiApi.php
+++ b/src/sprout/Helpers/AI/OpenAiApi.php
@@ -44,6 +44,21 @@ class OpenAiApi extends AiApiBase
     }
 
 
+    /** @inheritdoc */
+    public function getLastRequestCost(): mixed
+    {
+        $response = self::$_last_response;
+        return $response['usage']['total_tokens'];
+    }
+
+
+    /** @inheritdoc */
+    public function getRequestCostUnit(): string
+    {
+        return 'tokens';
+    }
+
+
     /**
      * Get the last response from the API
      *

--- a/src/sprout/Helpers/AI/WorkerAiContentProcess.php
+++ b/src/sprout/Helpers/AI/WorkerAiContentProcess.php
@@ -111,7 +111,7 @@ class WorkerAiContentProcess extends WorkerBase
                 $unit = $class->getRequestCostUnit();
                 Worker::message("Request cost: {$cost} {$unit}");
 
-                if (!isset($total_costs[$unit])) $total_costs[$unit] = 0;
+                $total_costs[$unit] ??= 0;
                 $total_costs[$unit] += $cost;
 
             } catch (Exception $e) {

--- a/src/sprout/Helpers/AI/WorkerAiContentProcess.php
+++ b/src/sprout/Helpers/AI/WorkerAiContentProcess.php
@@ -1,0 +1,116 @@
+<?php
+/*
+ * Copyright (C) 2023 Karmabunny Pty Ltd.
+ *
+ * This file is a part of SproutCMS.
+ *
+ * SproutCMS is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU General Public License as published by the Free Software Foundation, either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * For more information, visit <http://getsproutcms.com>.
+ */
+
+namespace Sprout\Helpers\AI;
+
+use Exception;
+use Kohana;
+use Sprout\Helpers\Pdb;
+use Sprout\Helpers\Worker;
+use Sprout\Helpers\WorkerBase;
+
+class WorkerAiContentProcess extends WorkerBase
+{
+    protected $job_name = 'Process AI Content Queue';
+
+
+    /**
+    * Process AI Content queue. 1 at a time to prevent overlap
+    **/
+    public function run()
+    {
+        $q_items = "SELECT * FROM ~ai_content_queue WHERE status = ? ORDER BY id ASC LIMIT 1";
+        $items = Pdb::query($q_items, ['queued'], 'arr');
+
+        // Result tracking vars
+        $success = $failed = 0;
+
+        while(count($items) > 0) {
+            $item = $items[0];
+            Worker::message("Generating AI content for record #{$item['target_id']} in {$item['target_table']}");
+
+            $active_msg = null;
+            $active_fields = [];
+
+            $class = new $item['class']();
+            $method = $item['method'];
+
+            $transacting = Pdb::inTransaction();
+            if (!$transacting) Pdb::transact();
+
+            // Update the queue entry to processing, so we can check for other items cleanly
+            Pdb::update('ai_content_queue', ['status' => 'processing'], ['id' => $item['id']]);
+
+            // See if we have any more fields to update for this table/record combo
+            $q_count = "SELECT COUNT(*) FROM ~ai_content_queue WHERE target_table = ? AND target_id = ? AND status = ?";
+
+            /** @var int */
+            $count = Pdb::query($q_count, [$item['target_table'], $item['target_id'], 'queued'], 'val');
+
+            // If we are finished with AI processing for this record, we can make changes to the active flag
+            if ($count == 0) {
+                switch ($item['activation_status']) {
+                    case 'active':
+                        $active_fields['active'] = 1;
+                        $active_msg = "Setting record #{$item['target_id']} in {$item['target_table']} to ACTIVE";
+                        break;
+                    case 'inactive':
+                        $active_fields['active'] = 0;
+                        $active_msg = "Setting record #{$item['target_id']} in {$item['target_table']} to INACTIVE";
+                        break;
+                    default:
+                        // Make no
+                        break;
+                }
+            }
+
+            try {
+                // Fire the actual AI class method to get the content
+                $output = $class::$method($item['prompt']);
+
+                // Merge the active flag change with the AI content
+                $data = array_merge([$item['target_col'] => $output], $active_fields);
+                Pdb::update($item['target_table'], $data, ['id' => $item['target_id']]);
+
+                Pdb::update('ai_content_queue', ['status' => 'complete'], ['id' => $item['id']]);
+
+                Worker::message("Updated content for record #{$item['target_id']} in {$item['target_table']}");
+                if ($active_msg) Worker::message($active_msg);
+
+                $success++;
+
+            } catch (Exception $e) {
+                // We will want this in the logs in case our integration has broken
+                Kohana::logException($e);
+
+                $log = $e->getMessage();
+                Pdb::update('ai_content_queue', ['status' => 'failed', 'log' => $log], ['id' => $item['id']]);
+
+                Worker::message("AI FAILED for record #{$item['target_id']} in {$item['target_table']}: {$log}");
+                $failed++;
+            }
+
+            if (!$transacting) Pdb::commit();
+
+            // Line break in output
+            Worker::message('');
+
+            $items = Pdb::query($q_items, ['queued'], 'arr');
+        }
+
+        Worker::message('AI Content Processed: ' . $success . ' success, ' . $failed . ' failed');
+        Worker::success();
+    }
+
+}
+

--- a/src/sprout/Helpers/AI/WorkerAiContentProcess.php
+++ b/src/sprout/Helpers/AI/WorkerAiContentProcess.php
@@ -16,6 +16,7 @@ namespace Sprout\Helpers\AI;
 use Exception;
 use Kohana;
 use Sprout\Helpers\Pdb;
+use Sprout\Helpers\Sprout;
 use Sprout\Helpers\Worker;
 use Sprout\Helpers\WorkerBase;
 
@@ -59,7 +60,7 @@ class WorkerAiContentProcess extends WorkerBase
             $active_msg = null;
             $active_fields = [];
 
-            $class = new $item['class']();
+            $class = Sprout::instance($item['class']);
             $method = $item['method'];
 
             $transacting = Pdb::inTransaction();

--- a/src/sprout/config/ai.php
+++ b/src/sprout/config/ai.php
@@ -1,0 +1,20 @@
+<?php
+/*
+ * Copyright (C) 2023 Karmabunny Pty Ltd.
+ *
+ * This file is a part of SproutCMS.
+ *
+ * SproutCMS is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU General Public License as published by the Free Software Foundation, either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * For more information, visit <http://getsproutcms.com>.
+ */
+
+/**
+ * Which class do we use for AI? Set null to disable
+ *
+ * @see AiHelper::AI_CLASSES - must match an array value (not key)
+ */
+$config['enabled_class'] = 'OpenAi';
+

--- a/src/sprout/config/openai.php
+++ b/src/sprout/config/openai.php
@@ -4,3 +4,11 @@
  * API Key for using GPT endpoints and such from OpenAI
  */
 $config['secret_key'] = '';
+
+
+/**
+ * Config options for chat completion requests
+ */
+$config['chat_completion'] = [
+    'max-tokens' => 3000,
+];

--- a/src/sprout/config/openai.php
+++ b/src/sprout/config/openai.php
@@ -1,0 +1,6 @@
+<?php
+
+/**
+ * API Key for using GPT endpoints and such from OpenAI
+ */
+$config['secret_key'] = '';

--- a/src/sprout/db_struct.xml
+++ b/src/sprout/db_struct.xml
@@ -675,6 +675,44 @@
         </index>
     </table>
 
+    <table name="ai_content_queue">
+        <column name="id" type="INT UNSIGNED" allownull="0" autoinc="1"/>
+        <column name="name" type="VARCHAR(50)" allownull="0"/>
+
+        <!-- Source details -->
+        <column name="prompt" type="TEXT" allownull="0"/>
+
+        <!-- Destination details -->
+        <column name="target_table" type="VARCHAR(255)" allownull="0"/>
+        <column name="target_id" type="INT UNSIGNED" allownull="0"/>
+        <column name="target_col" type="VARCHAR(255)" allownull="0"/> <!-- Where we put the data output -->
+
+        <!-- This allows us to override a record's 'active' flag after the AI cycle is finished -->
+        <column name="activation_status" type="ENUM('default', 'active', 'inactive')" allownull="0" default="default"/>
+
+        <!-- Target AI processor -->
+        <column name="class" type="VARCHAR(255)" allownull="0"/> <!-- Namespaced class name -->
+        <column name="method" type="VARCHAR(255)" allownull="0"/> <!-- Method on the AI class, e.g. chatCompletion -->
+
+        <column name="status" type="ENUM('queued', 'processing', 'complete', 'failed')" allownull="0" default="queued"/>
+
+        <column name="log" type="TEXT" allownull="1"/>
+
+        <column name="date_added" type="DATETIME"/>
+        <column name="date_modified" type="DATETIME"/>
+
+        <primary>
+            <col name="id"/>
+        </primary>
+
+        <index>
+            <col name="target_table" />
+        </index>
+        <index>
+            <col name="target_id" />
+        </index>
+    </table>
+
     <table name="redirects">
         <column name="id" type="INT UNSIGNED" allownull="0" autoinc="1" />
         <column name="date_added" type="DATETIME" />

--- a/src/sprout/views/admin/generic_import.php
+++ b/src/sprout/views/admin/generic_import.php
@@ -73,6 +73,9 @@ Form::setData($data);
     <?php echo $extra_options; ?>
 
 
+    <?php echo $ai_options; ?>
+
+
     <div class="action-bar">
         <button type="submit" class="button">Import data</button>
     </div>

--- a/src/sprout/views/admin/generic_import_ai.php
+++ b/src/sprout/views/admin/generic_import_ai.php
@@ -1,0 +1,97 @@
+<?php
+
+use Sprout\Helpers\AI\AI;
+use Sprout\Helpers\Form;
+use Sprout\Helpers\MultiEdit;
+use Sprout\Helpers\Pdb;
+
+$methods = AI::classesAndMethod();
+$heading_opts = array_combine($headings, $headings);
+
+Form::setData($data ?? []);
+?>
+
+<h3>AI Content Generation</h3>
+
+<script id="js--ai-methods" type="application/json">
+<?php echo json_encode($methods); ?>
+</script>
+
+<script>
+    function connectAiClasses($div,data,idx) {
+        // Update the method dropdown when the class dropdown changes
+        var methods = $('#js--ai-methods').html();
+        methods = JSON.parse(methods);
+
+        let $classField = $div.find('.ai_class');
+        let $methodField = $div.find('.ai_method');
+
+        $classField.on('change', function() {
+            var class_name = $(this).val();
+            var options = methods[class_name];
+
+            var html = '';
+            for (var key in options) {
+                html += '<option value="' + key + '">' + options[key] + '</option>';
+            }
+
+            $methodField.html(html);
+        }).change();
+    }
+</script>
+
+<p>You may add as much AI generated content as you like. Each entry will be used to generate content for the new record.
+    <br>Each simply needs a column in the import for the "prompt" text, then an assigned column in our database to store the generated content.</p>
+<p>For each AI content section, all fields are required, or the field will be silently skipped.</p>
+
+<div id="multiedit-ai_fields">
+    <div class="columns -clearfix">
+        <div class="column column-6">
+            <?php
+            Form::nextFieldDetails('AI Class', true, 'Which AI system will we use for content creation?');
+            echo Form::dropdown('m_ai_class', ['class' => 'ai_class'], AI::AI_CLASSES);
+            ?>
+        </div>
+
+        <div class="column column-6">
+            <?php
+            Form::nextFieldDetails('AI Endpoint', true, 'Which tool of this system are we using?');
+            echo Form::dropdown('m_ai_method', ['class' => 'ai_method'], []);
+            ?>
+        </div>
+    </div>
+
+    <div class="columns -clearfix">
+        <div class="column column-6">
+            <?php
+            Form::nextFieldDetails('Prompt column', true, 'This is the prompt we will use to generate content');
+            echo Form::dropdown('m_prompt_col', [], $heading_opts);
+            ?>
+        </div>
+
+        <div class="column column-6">
+            <?php
+            Form::nextFieldDetails('Target column', true, 'This is where we will add AI content to the new record');
+            echo Form::dropdown('m_target_col', [], $db_columns);
+            ?>
+        </div>
+    </div>
+</div>
+
+<?php
+MultiEdit::itemName('AI Content Entry');
+MultiEdit::setPostAddJavaScriptFunc('connectAiClasses');
+MultiEdit::display('ai_fields', $data['multiedit_ai_fields'] ?? []);
+?>
+
+<br>
+<h5>Status change after AI processing</h5>
+<p>You may update records to become active or inactive after processing.
+    <br>Select 'default' to leave them as they are by default post-import, or if this data type does not use an 'active' field.
+</p>
+
+<?php
+    Form::nextFieldDetails('Change activation status?', true, 'Do you want to change the activation status of the selected records after processing?');
+    echo Form::dropdown('ai_activation_status', ['-dropdown-top' => ''], Pdb::extractEnumArr('ai_content_queue', 'activation_status'));
+    ?>
+</div>

--- a/src/sprout/views/dbtools/openai_test.php
+++ b/src/sprout/views/dbtools/openai_test.php
@@ -16,6 +16,13 @@ use Sprout\Helpers\AI\OpenAiApi;
         <?php Form::nextFieldDetails('Input prompt', true, 'NOTE: This is a single prompt, not threaded'); ?>
         <?php echo Form::multiline('prompt', []); ?>
 
+        <?php Form::nextFieldDetails('Additional data', true); ?>
+        <?php echo Form::dropdown('debug_data',['-dropdown-top' => ''],  [
+            '' => 'None - Response only',
+            'tokens' => 'Tokens used',
+            'debug' => 'Full debug data',
+        ]); ?>
+
         <button type="submit" class="button no-disable js--ai-submit">Get OpenAI response</button>
     </form>
 </div>

--- a/src/sprout/views/dbtools/openai_test.php
+++ b/src/sprout/views/dbtools/openai_test.php
@@ -1,0 +1,24 @@
+<?php
+
+use Sprout\Helpers\Csrf;
+use Sprout\Helpers\Form;
+use Sprout\Helpers\AI\OpenAiApi;
+
+?>
+
+<div>
+    <form method="POST" action="dbtools/openAiTestSubmit" target="tester">
+        <?php echo Csrf::token(); ?>
+
+        <?php Form::nextFieldDetails('AI Endpoint', true); ?>
+        <?php echo Form::dropdown('endpoint',[],  OpenAiApi::ENDPOINTS); ?>
+
+        <?php Form::nextFieldDetails('Input prompt', true, 'NOTE: This is a single prompt, not threaded'); ?>
+        <?php echo Form::multiline('prompt', []); ?>
+
+        <button type="submit" class="button no-disable js--ai-submit">Get OpenAI response</button>
+    </form>
+</div>
+
+<p>&nbsp;</p>
+<iframe style="width: 100%; height: 1050px" name="tester"></iframe>


### PR DESCRIPTION
This brings in a few concepts:

1. AI APIs, inside a new core AI namespace, with a common base class
2. DB Tools for testing our 1 current AI API class (Open AI) - supports chat completions and image endpoints
4. A new table for staging content requirements for AI creation
5. A worker job for processing the AI content queue
6. A DB Tools function to fire the AI worker processing queue job
7. An interface hook in the content import process for adding AI driven content
8. Import option to change record 'active' status after all AI queue items complete for that record
9. New extensible sections throughout the importer for processing AI content

DBTools:
![image](https://github.com/Karmabunny/sprout3/assets/25573428/f7396e27-8979-4929-96a7-f0e1731fd7e2)
![image](https://github.com/Karmabunny/sprout3/assets/25573428/a2f4a725-1b75-414f-b281-a84cdfd95d3c)

Import tooling:
![image](https://github.com/Karmabunny/sprout3/assets/25573428/4df7f5a6-4bb7-461b-920c-3747e40a2cc2)
![image](https://github.com/Karmabunny/sprout3/assets/25573428/790438b0-48cd-4434-83de-b32bfbf02592)


Worker Job:
![image](https://github.com/Karmabunny/sprout3/assets/25573428/83918f0f-327d-4385-984e-c79dda58e824)


