### PR TITLE
Fix/sign key

### DIFF
--- a/src/sprout/Helpers/Security.php
+++ b/src/sprout/Helpers/Security.php
@@ -15,6 +15,7 @@ namespace Sprout\Helpers;
 
 use Exception;
 use InvalidArgumentException;
+use karmabunny\kb\Arrays;
 use karmabunny\kb\Secrets;
 use Kohana;
 use Kohana_Exception;
@@ -172,9 +173,13 @@ class Security
      */
     public static function serverKeySign(array $fields)
     {
-        sort($fields);
+        if (Arrays::isAssociated($fields)) {
+            ksort($fields);
+        } else {
+            sort($fields);
+        }
+
         $data = http_build_query($fields);
-        $data = strtolower($data);
 
         $key = self::getServerKey();
 

--- a/tests/SecurityHelperTest.php
+++ b/tests/SecurityHelperTest.php
@@ -231,4 +231,43 @@ class SecurityHelperTest extends TestCase
         $this->assertEquals($errmsg?[$errmsg]:[], $errs);
     }
 
+
+    public static function dataKeySign()
+    {
+        return [
+            ['583e69759d930699493a0b7828aed9d957b8ffe7', ['abc' => 'DEF', 'ghi' => 123]],
+
+            // out of order (same)
+            ['583e69759d930699493a0b7828aed9d957b8ffe7', ['ghi' => 123, 'abc' => 'DEF']],
+
+            // swapped keys
+            ['7c3df8577308800d36f975086130f803224abadc', ['ghi' => 'DEF', 'abc' => 123]],
+
+            // different keys
+            ['c832c7da6994d50c20e02d235eec0d0dd67d3181', ['wtf' => 'DEF', 'ghi' => 123]],
+
+            // lowercase
+            ['67453d5afbe7be763eb9353ff4f949e0759837a6', ['abc' => 'def', 'ghi' => 123]],
+
+            // no keys
+            ['80d01ed1edbcfe0b29f6ab072d1c0c5451d0e3da', ['DEF', 123]],
+
+            // original test
+            ['50a9461490976af56edb047ab6af9acba22d0474', ['def', 123]],
+
+            // same again
+            ['50a9461490976af56edb047ab6af9acba22d0474', [123, 'def']],
+        ];
+    }
+
+
+    /**
+     * @dataProvider dataKeySign
+     */
+    public function testKeySign($expected, $actual)
+    {
+        $actual = Security::serverKeySign($actual);
+        $this->assertTrue(hash_equals($expected, $actual), $actual);
+    }
+
 }


### PR DESCRIPTION
It's a little abstract and you may need to look at it sideways.

The test case should explain most of it. Without correct sorts and with the `strtolower()` the signature was the same for each of those assert tests. It was a surprising behaviour to discover.

Can we imagine this change breaking anything?
I don't know if we're actively using this outside of file resize signatures.