### PR TITLE
Feat/ai content tools

### DIFF
--- a/src/sprout/Controllers/DbToolsController.php
+++ b/src/sprout/Controllers/DbToolsController.php
@@ -28,6 +28,7 @@ use Kohana_Exception;
 use karmabunny\pdb\Exceptions\QueryException;
 use karmabunny\pdb\Exceptions\RowMissingException;
 use karmabunny\pdb\PdbParser;
+use PDOStatement;
 use Sprout\Exceptions\ValidationException;
 use Sprout\Exceptions\WorkerJobException;
 use Sprout\Helpers\Admin;
@@ -122,6 +123,7 @@ class DbToolsController extends Controller
             [ 'url' => 'dbtools/openAiTest', 'name' => 'Open AI Tester', 'desc' => 'Prompt tester for Open AI' ],
             [ 'url' => 'dbtools/processAiContentQueue', 'name' => 'Process AI Content Queue', 'desc' => 'Worker to process items in AI content queue' ],
             [ 'url' => 'dbtools/processAiContentQueue?retry=1', 'name' => 'Retry AI Content Queue', 'desc' => 'Process AI content queue and retry any failed items' ],
+            [ 'url' => 'dbtools/openAiTools', 'name' => 'Open AI Content Manager', 'desc' => 'Tools for managing files, assistants etc' ],
         ],
         'Environment' => [
             [ 'url' => 'dbtools/info', 'name' => 'Env and PHP info', 'desc' => 'Sprout information + phpinfo()' ],
@@ -1079,15 +1081,15 @@ class DbToolsController extends Controller
         $('#select-all-none').click(function(){
             var all_checked = true;
             $("input[name*='tables[']").each(function() {
-                if (!$(this).attr('checked')) all_checked = false;
+                if (!$(this).prop('checked')) all_checked = false;
             });
             if (all_checked) {
                 $("input[name*='tables[']").each(function() {
-                    $(this).removeAttr('checked');
+                    $(this).prop('checked', false);
                 });
             } else {
                 $("input[name*='tables[']").each(function() {
-                    $(this).attr('checked', 'checked');
+                    $(this).prop('checked', true);
                 });
             }
             return false;
@@ -1207,15 +1209,16 @@ class DbToolsController extends Controller
             $export->split_table = true;
         }
 
+        $amt = 0;
         $matches = array();
         if (
             isset($_POST['split_size'])
             and isset($_POST['split_amount'])
             and preg_match('/([0-9]+)\s?([kmg])/', $_POST['split_amount'], $matches)
         ) {
-            if ($matches[2] == 'k') $amt = $matches[1] * 1000;
-            if ($matches[2] == 'm') $amt = $matches[1] * 1000 * 1000;
-            if ($matches[2] == 'g') $amt = $matches[1] * 1000 * 1000 * 1000;
+            if ($matches[2] == 'k') $amt = ((int) $matches[1] * 1000);
+            if ($matches[2] == 'm') $amt = ((int) $matches[1] * 1000 * 1000);
+            if ($matches[2] == 'g') $amt = ((int) $matches[1] * 1000 * 1000 * 1000);
             $export->split_size = $amt;
         }
 
@@ -1609,6 +1612,110 @@ class DbToolsController extends Controller
         echo '<br><br><hr><br>';
         $raw = OpenAiApi::getTokensUsed();
         echo '<pre>', Enc::html(print_r($raw, true)), '</pre>';
+    }
+
+
+    /**
+     * Render a list of tools for managing OpenAI
+     *
+     * @return void
+     */
+    public function openAiTools()
+    {
+        foreach (OpenAiApi::ITEM_TYPES as $item_type => $item) {
+            $item_name = Enc::html($item['name']);
+            $item_description = Enc::html($item['description']);
+
+            echo '<div class="highlight">';
+            echo "<h4>{$item_name}</h4>";
+            echo "<p>{$item_description}</p>";
+            echo '<p>';
+            echo '<a class="button" href="SITE/dbtools/openAiList/', $item_type, '">List all ', $item_name, '</a>';
+            echo ' | <a class="button button-red" href="SITE/dbtools/openAiPurge/', $item_type,
+                '" onclick="return confirm(\'This will remove EVERY ', $item_name, ' item - confirm?\')">Delete all  ', $item_name, '</a>';
+            echo '</p>';
+            echo '</div>';
+        }
+
+        $this->template('OpenAI API Content Management');
+    }
+
+
+    /**
+     * Render a list of items stored with Open AI for a given type
+     *
+     * @param string $type Eg `files` or `assistants`
+     *
+     * @return void
+     */
+    public function openAiList(string $type)
+    {
+        $type = strtolower($type);
+        $items = OpenAiApi::listItems($type);
+
+        $item_opts = [];
+        foreach ($items['data'] as $item)  {
+            $item_opts[$item['id']] = json_encode($item);
+        }
+
+        $view = new PhpView('sprout/dbtools/openai_list');
+        $view->type = $type;
+        $view->item_opts = $item_opts;
+
+        echo $view->render();
+
+        $open_ai_type = OpenAiApi::ITEM_TYPES[$type];
+        $this->template("OpenAI {$open_ai_type['name']}");
+    }
+
+
+    /**
+     * List all items for a given type
+     *
+     * @param string $type as per OpenAiApi::ITEM_TYPES keys
+     *
+     * @return never
+     */
+    public function openAiListAction(string $type)
+    {
+        if (empty($_POST['action'])) {
+            Notification::error('No action specified');
+            Url::redirect("dbtools/openAiList/{$type}");
+        }
+
+        if (empty($_POST['items'])) {
+            Notification::error('No items specified');
+            Url::redirect("dbtools/openAiList/{$type}");
+        }
+
+
+        if ($_POST['action'] == 'delete') {
+            $num_deleted = OpenAiApi::deleteItems($type, $_POST['items']);
+            Notification::confirm("Deleted {$num_deleted} items");
+            Url::redirect("dbtools/openAiList/{$type}");
+        }
+
+        Url::redirect("dbtools/openAiTools");
+    }
+
+
+    /**
+     * Trigger a delete-all for a given type
+     *
+     * @param string $type as per OpenAiApi::ITEM_TYPES keys
+     *
+     * @return never
+     */
+    public function openAiPurge(string $type)
+    {
+        try {
+            $worker = WorkerCtrl::start('Sprout\\Helpers\\AI\\WorkerOpenAiPurge', $type, []);
+        } catch (WorkerJobException $ex) {
+            Notification::error("Unable to start background process: {$ex->getMessage()}");
+            Url::redirect("dbtools/openAiTools");
+        }
+
+        Url::redirect($worker['log_url']);
     }
 
 

--- a/src/sprout/Helpers/AI/OpenAiApi.php
+++ b/src/sprout/Helpers/AI/OpenAiApi.php
@@ -238,4 +238,38 @@ class OpenAiApi implements AiApiInterface
         return $response['data'][0]['b64_json'];
     }
 
+
+    /**
+     * List items of a given type. Note that returns the first page only.
+     *
+     * @param string $type
+     * @param null|array $config
+     *
+     * @return array The item list
+     */
+    public static function listItems(string $type, ?array $config = []): array
+    {
+        // Optional default config load
+        if (empty($config)) {
+            $config = Kohana::config('openai') ?? [];
+        }
+
+        if (!array_key_exists($type, self::ITEM_TYPES)) {
+            throw new InvalidArgumentException("Invalid type: $type");
+        }
+
+        // Exceptions need catching by caller
+        $key = $config['secret_key'];
+
+        /** @var Client */
+        $client = OpenAI::client($key);
+
+        $response = match($type)  {
+            'files' => $client->files()->list(),
+            'assistants' => $client->assistants()->list(),
+            default => throw new InvalidArgumentException("Invalid type: $type"),
+        };
+
+        return $response->toArray();
+    }
 }

--- a/src/sprout/Helpers/AI/OpenAiApi.php
+++ b/src/sprout/Helpers/AI/OpenAiApi.php
@@ -12,14 +12,10 @@
  */
 namespace Sprout\Helpers\AI;
 
-use Http\Discovery\Exception\NotFoundException;
 use Kohana;
-use Kohana_Exception;
 use OpenAI;
-use OpenAI\Exceptions\ErrorException;
+use OpenAI\Client;
 use OpenAI\Exceptions\InvalidArgumentException;
-use OpenAI\Exceptions\UnserializableResponse;
-use OpenAI\Exceptions\TransporterException;
 use OpenAI\Responses\Chat\CreateResponse as ChatCreateResponse;
 use OpenAI\Responses\Images\CreateResponse as ImageCreateResponse;
 
@@ -37,6 +33,24 @@ class OpenAiApi implements AiApiInterface
         'chatCompletion' => 'Chat Completions',
         'imageGenerateSrc' => 'Image Generation - External URL',
         'imageGenerateBlob' => 'Image Generation - Image Data',
+    ];
+
+
+    /**
+     * Items that can be created / stored / listed / deleted
+     *
+     * @see self::listItems and self::deleteItems
+     * Also used in DB Tools
+     */
+    const ITEM_TYPES = [
+        'files' => [
+            'name' => 'Files',
+            'description' => 'Files are used to store data that can be used in completions, such as documents, images, and more.',
+        ],
+        'assistants' => [
+            'name' => 'Assistants',
+            'description' => 'Assistants are used to aid in specific tasks, or drive highly customised chat bots.',
+        ],
     ];
 
 
@@ -91,6 +105,7 @@ class OpenAiApi implements AiApiInterface
     public static function getTokensUsed(): array
     {
         $response = self::$_last_response;
+
         return $response['usage'] ?? [
             'completion_tokens' => 0,
             'prompt_tokens' => 0,
@@ -105,13 +120,6 @@ class OpenAiApi implements AiApiInterface
      * @param array $config
      *
      * @return string|null
-     *
-     * @throws Kohana_Exception
-     * @throws NotFoundException
-     * @throws InvalidArgumentException
-     * @throws ErrorException
-     * @throws UnserializableResponse
-     * @throws TransporterException
      */
     public static function chatCompletion(string|array $prompt, array $config = []): ?string
     {
@@ -157,13 +165,6 @@ class OpenAiApi implements AiApiInterface
      * @param array $config
      *
      * @return string|null Image src URL
-     *
-     * @throws Kohana_Exception
-     * @throws NotFoundException
-     * @throws InvalidArgumentException
-     * @throws ErrorException
-     * @throws UnserializableResponse
-     * @throws TransporterException
      */
     public static function imageGenerateSrc(string $prompt, array $config = []): ?string
     {

--- a/src/sprout/Helpers/AI/WorkerOpenAiPurge.php
+++ b/src/sprout/Helpers/AI/WorkerOpenAiPurge.php
@@ -1,0 +1,59 @@
+<?php
+/*
+ * Copyright (C) 2023 Karmabunny Pty Ltd.
+ *
+ * This file is a part of SproutCMS.
+ *
+ * SproutCMS is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU General Public License as published by the Free Software Foundation, either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * For more information, visit <http://getsproutcms.com>.
+ */
+
+namespace Sprout\Helpers\AI;
+
+use InvalidArgumentException;
+use Sprout\Helpers\Worker;
+use Sprout\Helpers\WorkerBase;
+
+class WorkerOpenAiPurge extends WorkerBase
+{
+    protected $job_name = 'Bulk Delete OpenAI items';
+
+
+    /**
+     * Delete all the items for a given type
+     *
+     * @param string $type As per OpenAiApi::ITEM_TYPES
+     * @param null|array $config Optional openai config override
+    **/
+    public function run(string $type, ?array $config = [])
+    {
+        // Line break in output
+        Worker::message('');
+        if (!array_key_exists($type, OpenAiApi::ITEM_TYPES)) {
+            throw new InvalidArgumentException("Invalid type: $type");
+        }
+
+        Worker::message("Deleting all {$type} from OpenAI");
+
+        $deleted_total = 0;
+        $items = OpenAiApi::listItems($type, $config);
+
+        while (count($items['data']) > 0) {
+            $item_ids = array_column($items['data'], 'id');
+
+            $deleted = OpenAiApi::deleteItems($type, $item_ids, $config);
+            $deleted_total += $deleted;
+
+            Worker::message("Deleted {$deleted} items ({$deleted_total} total)");
+
+            $items = OpenAiApi::listItems($type, $config);
+        }
+
+        Worker::success();
+    }
+
+}
+

--- a/src/sprout/views/dbtools/openai_list.php
+++ b/src/sprout/views/dbtools/openai_list.php
@@ -1,0 +1,60 @@
+<?php
+
+use Sprout\Helpers\Csrf;
+use Sprout\Helpers\Form;
+use Sprout\Helpers\Enc;
+
+?>
+
+<style>
+    .json-data {
+        word-break: break-all;
+    }
+    .json-data .fieldset-input {
+        margin-bottom: 10px;
+    }
+</style>
+
+<p>
+    <a href="dbtools/openAiTools">&laquo; Return to tools list</a>
+    | <a class="preview" id="select-all-none" href="javascript:;">Select all/none</a>
+</p>
+
+<script type="text/javascript">
+$('#select-all-none').click(function(){
+    var all_checked = true;
+    $("input[name*='items[']").each(function() {
+        if (!$(this).prop('checked')) all_checked = false;
+    });
+    if (all_checked) {
+        $("input[name*='items[']").each(function() {
+            $(this).prop('checked', false);
+        });
+    } else {
+        $("input[name*='items[']").each(function() {
+            $(this).prop('checked', true);
+        });
+    }
+    return false;
+});
+</script>
+
+<div>
+    <form method="POST" action="dbtools/openAiListAction/<?php echo Enc::html($type); ?>">
+        <?php echo Csrf::token(); ?>
+
+        <?php Form::nextFieldDetails('Items', false); ?>
+        <div class="json-data">
+            <?php echo Form::checkboxSet('items', [], $item_opts); ?>
+        </div>
+
+        <?php Form::nextFieldDetails('Action', true); ?>
+        <?php echo Form::dropdown('action',['-dropdown-top' => ''],  [
+            '' => 'None',
+            'delete' => 'Delete',
+        ]); ?>
+
+        <button type="submit" class="button">Process Action</button>
+    </form>
+</div>
+


### PR DESCRIPTION
Tooling to enable viewing and deletion of content created in OpenAI. Some of which (esp files) incur an ongoing hosting cost, so this is important.

I tested this on files and assistants built for one of our major projects, and cleaned them out successfully.

**Draft** because I may add pagination to the main listing

![image](https://github.com/Karmabunny/sprout3/assets/25573428/ecc1a51e-75ed-4ab5-8a4c-20b7c31c2de0)


![image](https://github.com/Karmabunny/sprout3/assets/25573428/229cde03-0763-4bb3-8296-633541a23a69)
