### PR TITLE
Allowing config override to disable CORS header checks

### DIFF
--- a/src/sprout/Helpers/Cors.php
+++ b/src/sprout/Helpers/Cors.php
@@ -138,7 +138,7 @@ class Cors
         // $errors[] = 'bad origin';
 
         // Validate permitted headers.
-        if (count(array_intersect($config['headers'], $headers)) !== count($headers)) {
+        if (empty($config['ignore_headers']) and count(array_intersect($config['headers'], $headers)) !== count($headers)) {
             $errors[] = 'bad headers';
         }
 


### PR DESCRIPTION
A simple config override that will allow us to skip header checks.

This is for scenarios such as behind CloudFlare, where it injects its own non-standard headers.

Tested and deployed to a prod site already.