### PR TITLE
Add support for profiling per-session.

### DIFF
--- a/src/sprout/Controllers/DbToolsController.php
+++ b/src/sprout/Controllers/DbToolsController.php
@@ -2562,6 +2562,16 @@ class DbToolsController extends Controller
 
 
     /**
+     * Update the session override for profiling.
+     */
+    public function profilingLogSessionOverride()
+    {
+        Profiling::setEnabledSession($_POST['enabled'] ?? null);
+        url::redirect('dbtools/profilingLog');
+    }
+
+
+    /**
      * View a single profile log item.
      */
     public function profilingLogItem()

--- a/src/sprout/views/dbtools/profiling_log.php
+++ b/src/sprout/views/dbtools/profiling_log.php
@@ -1,6 +1,7 @@
 <?php
 use Sprout\Helpers\Enc;
 use Sprout\Helpers\Form;
+use Sprout\Helpers\Profiling;
 use Sprout\Helpers\Url;
 
 Form::setData($_GET);
@@ -15,9 +16,11 @@ $next_query = http_build_query($get);
 $get['page'] = $get['page'] - 2;
 $prev_query = http_build_query($get);
 
+$profiling_enabled = Profiling::isEnabledForUrl('');
 ?>
 
 <div class="mainbar mainbar--wide">
+
     <form action="" method="get" class="white-box">
         <h3 style="margin-top: 0">Search</h3>
 
@@ -49,8 +52,17 @@ $prev_query = http_build_query($get);
         </div>
     </form>
 
-    <div><?php echo $total_row_count; ?> records</div>
-    <div><?php echo sprintf('%.4f', $total_time); ?> second</div>
+    <div style="display: inline-block">
+        <div><?php echo $total_row_count; ?> records</div>
+        <div><?php echo sprintf('%.4f', $total_time); ?> second</div>
+    </div>
+
+    <form action="dbtools/profilingLogSessionOverride" method="post" style="display: inline-block; float: right">
+        <input type="hidden" name="enabled" value="<?= (int)!$profiling_enabled ?>" />
+        <button type="submit" class="button">
+            Profiling: <?= $profiling_enabled ? 'Disable' : 'Enable' ?>
+        </button>
+    </form>
 
     <?php echo $itemlist; ?>
 


### PR DESCRIPTION
Something I wrote ages ago. Seems useful still.

Basically profiling is typically disabled in production, but sometimes you want to see the things - you know? So this lets one do just that for their own session without tanking the site for everyone else.