### PR TITLE
Feat/inline twig

### DIFF
--- a/src/sprout/Helpers/TwigView.php
+++ b/src/sprout/Helpers/TwigView.php
@@ -112,6 +112,19 @@ class TwigView extends BaseView
 
 
     /**
+     * Render an inline twig template.
+     *
+     * @param string $template
+     * @param array $data
+     * @return string
+     */
+    public static function renderString(string $template, array $data = []): string
+    {
+        return self::getTwig()->createTemplate($template)->render($data);
+    }
+
+
+    /**
      * Not actually deprecated - this will always exist.
      * Just for clarity please use the base class.
      *

--- a/src/sprout/Helpers/TwigView.php
+++ b/src/sprout/Helpers/TwigView.php
@@ -31,8 +31,6 @@ use Twig\Template;
  *
  * Sprout exposes a global `sprout` variable for helpers and modules.
  * {@see SproutVariable}
- *
- * @todo - There's lots of opportunity to cache these templates.
  */
 class TwigView extends BaseView
 {
@@ -48,10 +46,8 @@ class TwigView extends BaseView
     protected $kohana_template_name;
 
 
-    /** @inheritdoc */
-    public function __construct($name, array $data = [])
+    public static function getTwig(): Environment
     {
-        // Initialise the twig renderer.
         if (!isset(self::$twig)) {
             $cache_path = STORAGE_PATH . 'cache/twig_templates';
 
@@ -74,6 +70,16 @@ class TwigView extends BaseView
             self::$twig->addExtension(new SproutExtension());
         }
 
+        return self::$twig;
+    }
+
+
+    /** @inheritdoc */
+    public function __construct($name, array $data = [])
+    {
+        // Initialise the twig renderer.
+        self::getTwig();
+
         $this->kohana_template_name = $name;
         parent::__construct($name, $data);
     }
@@ -86,7 +92,7 @@ class TwigView extends BaseView
             throw new Kohana_Exception('core.view_set_filename');
         }
 
-        $output = self::$twig->render($this->kohana_template_name, $this->kohana_local_data);
+        $output = self::getTwig()->render($this->kohana_template_name, $this->kohana_local_data);
 
         if ($renderer !== FALSE AND is_callable($renderer, TRUE))
         {
@@ -141,10 +147,12 @@ class TwigView extends BaseView
                 return null;
             }
 
+            $twig = self::getTwig();
+
             [, $class] = $matches;
 
             /** @var Template $template */
-            $template = new $class(self::$twig);
+            $template = new $class($twig);
             $source = $template->getSourceContext();
 
             // The template file path.


### PR DESCRIPTION
Twig string templates. Handy things.

These are something you can hand to (admin) users to do little snippets of logic from a content managed environment.

Use it something like:

```php
$items = [
   ['name' => 'abc'],
   ['bad'],
   ['name' => 'def'],
];
$template = '{{ items|map(item => item.name ?? false)|filter|join(', ') }}';
$html = TwigView::renderString($template, [ 'items' => $items ]);
```