### PR TITLE
Fix/module loading order

### DIFF
--- a/src/bootstrap/phpunit.php
+++ b/src/bootstrap/phpunit.php
@@ -13,6 +13,7 @@
 
 use karmabunny\pdb\Exceptions\PdbException;
 use Sprout\Helpers\DatabaseSync;
+use Sprout\Helpers\Modules;
 use Sprout\Helpers\SubsiteSelector;
 use Sprout\Helpers\Pdb;
 
@@ -32,6 +33,14 @@ require APPPATH . 'core/Kohana.php';
 
 // Prepare the environment
 Kohana::setup();
+
+// Initialise Sprout modules, if required
+$modules = Modules::getModules();
+foreach ($modules as $mod) {
+    if ($mod->isLoaded()) continue;
+    $mod->loadSprout();
+}
+
 SubsiteSelector::selectSubsite();
 
 // Allow both old and new versions of phpunit to work

--- a/src/sprout/core/Bootstrap.php
+++ b/src/sprout/core/Bootstrap.php
@@ -24,6 +24,7 @@
 
 use karmabunny\kb\Events;
 use Sprout\Events\NotFoundEvent;
+use Sprout\Helpers\Modules;
 use Sprout\Helpers\Notification;
 use Sprout\Helpers\PageRouting;
 use Sprout\Helpers\Router;
@@ -81,6 +82,13 @@ if (Sprout::moduleInstalled('Welcome')) {
         Notification::confirm('Or please log in to admin area using the form below.');
         Url::redirect('admin/');
     }
+}
+
+// Initialise Sprout modules, if required
+$modules = Modules::getModules();
+foreach ($modules as $mod) {
+    if ($mod->isLoaded()) continue;
+    $mod->loadSprout();
 }
 
 // Choose the subsite to use, based on domain, directory, mobile etc.

--- a/src/sprout/core/Kohana.php
+++ b/src/sprout/core/Kohana.php
@@ -273,20 +273,13 @@ final class Kohana {
                 die;
             }
 
-            // Initialise Sprout modules, if required
-            $modules = Modules::getModules();
-            foreach ($modules as $mod) {
-                if ($mod->isLoaded()) continue;
-                $mod->loadSprout();
-            }
-
-            // Prevent further service registrations
-            Services::lock();
-
             // Initialise any custom non-module code
             if (is_readable(DOCROOT . '/skin/sprout_load.php')) {
                 require DOCROOT . '/skin/sprout_load.php';
             }
+
+            // Prevent further service registrations
+            Services::lock();
 
             // Run system.pre_controller
             $event = new PreControllerEvent();


### PR DESCRIPTION
Rejigging loading sequence for modules to put them ahead of any system dependencies.

Loading directly in bootstrap lets us load in external admin auth systems etc, as these were previously instantiated before module loading.

Updating PhpUnit bootstrap to match