### PR TITLE
Add busty Twig filter/function for cache busting URLs

### DIFF
--- a/src/sprout/Helpers/SproutExtension.php
+++ b/src/sprout/Helpers/SproutExtension.php
@@ -408,7 +408,7 @@ final class SproutExtension
         $url_query_separator_pos = strrpos($normalized_url, '?');
 
         if ($url_query_separator_pos !== false) {
-            $normalized_url = substr($normalized_url, 0, strrpos($normalized_url, '?'));
+            $normalized_url = substr($normalized_url, 0, $url_query_separator_pos);
         }
 
         $file = $normalized_docroot_path . DIRECTORY_SEPARATOR . $normalized_url;

--- a/src/sprout/Helpers/SproutExtension.php
+++ b/src/sprout/Helpers/SproutExtension.php
@@ -90,6 +90,7 @@ final class SproutExtension
             new TwigFilter('push', [$this, 'push'], ['is_variadic' => true]),
             new TwigFilter('unshift', [$this, 'unshift'], ['is_variadic' => true]),
             new TwigFilter('shuffle', [$this, 'shuffle']),
+            new TwigFilter('busty', [$this, 'bustyUrl']),
         ];
     }
 
@@ -119,6 +120,7 @@ final class SproutExtension
             new TwigFunction('options', [$this, 'options'], [
                 'is_safe' => ['html'],
             ]),
+            new TwigFunction('busty', [$this, 'bustyUrl']),
         ];
     }
 
@@ -390,4 +392,34 @@ final class SproutExtension
             return $array;
         }
     }
+
+
+    /**
+     * Create a URL with a timestamp for cache busting purposes.
+     *
+     * @param string $url The URL as provided by the Twig template.
+     * @param string $sub_directory An optional subdirectory string to append to the site's base path.
+     * @return string
+     */
+    public function bustyUrl($url, $sub_directory=""): string
+    {
+        $normalized_base_path = rtrim(BASE_PATH, DIRECTORY_SEPARATOR);
+        $normalized_sub_directory = trim($sub_directory, DIRECTORY_SEPARATOR);
+        $normalized_url = trim(Needs::replacePathsString($url), DIRECTORY_SEPARATOR);
+
+        $file = $normalized_base_path;
+
+        if (!empty($normalized_sub_directory)) {
+            $file .= DIRECTORY_SEPARATOR . $normalized_sub_directory;
+        }
+
+        $file .= DIRECTORY_SEPARATOR . $normalized_url;
+
+        if ($file) {
+            $mtime = @filemtime($file) ?: null;
+        }
+
+        return $url . '?_v=' . ($mtime ?? 0);
+    }
+
 }

--- a/src/sprout/Helpers/SproutExtension.php
+++ b/src/sprout/Helpers/SproutExtension.php
@@ -398,22 +398,14 @@ final class SproutExtension
      * Create a URL with a timestamp for cache busting purposes.
      *
      * @param string $url The URL as provided by the Twig template.
-     * @param string $sub_directory An optional subdirectory string to append to the site's base path.
      * @return string
      */
-    public function bustyUrl($url, $sub_directory=""): string
+    public function bustyUrl($url): string
     {
-        $normalized_base_path = rtrim(BASE_PATH, DIRECTORY_SEPARATOR);
-        $normalized_sub_directory = trim($sub_directory, DIRECTORY_SEPARATOR);
+        $normalized_docroot_path = rtrim(DOCROOT, DIRECTORY_SEPARATOR);
         $normalized_url = trim(Needs::replacePathsString($url), DIRECTORY_SEPARATOR);
 
-        $file = $normalized_base_path;
-
-        if (!empty($normalized_sub_directory)) {
-            $file .= DIRECTORY_SEPARATOR . $normalized_sub_directory;
-        }
-
-        $file .= DIRECTORY_SEPARATOR . $normalized_url;
+        $file = $normalized_docroot_path . DIRECTORY_SEPARATOR . $normalized_url;
 
         if ($file) {
             $mtime = @filemtime($file) ?: null;

--- a/src/sprout/Helpers/SproutExtension.php
+++ b/src/sprout/Helpers/SproutExtension.php
@@ -405,6 +405,12 @@ final class SproutExtension
         $normalized_docroot_path = rtrim(DOCROOT, DIRECTORY_SEPARATOR);
         $normalized_url = trim(Needs::replacePathsString($url), DIRECTORY_SEPARATOR);
 
+        $url_query_separator_pos = strrpos($normalized_url, '?');
+
+        if ($url_query_separator_pos !== false) {
+            $normalized_url = substr($normalized_url, 0, strrpos($normalized_url, '?'));
+        }
+
         $file = $normalized_docroot_path . DIRECTORY_SEPARATOR . $normalized_url;
 
         if ($file) {

--- a/src/sprout/Helpers/SproutExtension.php
+++ b/src/sprout/Helpers/SproutExtension.php
@@ -417,7 +417,7 @@ final class SproutExtension
             $mtime = @filemtime($file) ?: null;
         }
 
-        return $url . '?_v=' . ($mtime ?? 0);
+        return Url::withParams($url, ['_v' => $mtime ?? 0 ]);
     }
 
 }

--- a/src/sprout/Helpers/Url.php
+++ b/src/sprout/Helpers/Url.php
@@ -278,6 +278,34 @@ class Url
         return $url_base;
     }
 
+    /**
+    * Appends query string parameter(s) to a URL.
+    *
+    * Supports URLs that already contain query string parameters,
+    * and those that do not.
+    *
+    * @param string $url
+    * @param string[] $params
+    * @return string
+    **/
+    public static function withParams($url, $params)
+    {
+        if (empty($params)) return $url;
+
+        $existing_query_params = parse_url($url, PHP_URL_QUERY);
+        $url .= $existing_query_params ? '&' : '?';
+
+        $new_query_parts = [];
+
+        foreach ($params as $key => $value) {
+            $new_query_parts[] = urlencode($key) . '=' . urlencode($value);
+        }
+
+        $url .= implode('&', $new_query_parts);
+
+        return $url;
+    }
+
 
     /**
     * Checks the provided argument is a valid redirect URL to the local site

--- a/src/sprout/Helpers/Url.php
+++ b/src/sprout/Helpers/Url.php
@@ -302,10 +302,7 @@ class Url
             $url = substr($url, 0, strrpos($url, '?'));
         }
 
-        $all_query_params = array_merge($existing_query_params, $params);
-        $new_query_param_string = http_build_query($all_query_params);
-
-        return $url . '?' . $new_query_param_string;
+        return $url . '?' . http_build_query(array_merge($existing_query_params, $params));
     }
 
 

--- a/src/sprout/Helpers/Url.php
+++ b/src/sprout/Helpers/Url.php
@@ -292,18 +292,20 @@ class Url
     {
         if (empty($params)) return $url;
 
-        $existing_query_params = parse_url($url, PHP_URL_QUERY);
-        $url .= $existing_query_params ? '&' : '?';
+        // Returns a string of the parameters, false if malformed or null if no query string component
+        $existing_query_string = parse_url($url, PHP_URL_QUERY);
 
-        $new_query_parts = [];
+        $existing_query_params = [];
 
-        foreach ($params as $key => $value) {
-            $new_query_parts[] = urlencode($key) . '=' . urlencode($value);
+        if ($existing_query_string) {
+            parse_str($existing_query_string, $existing_query_params);
+            $url = substr($url, 0, strrpos($url, '?'));
         }
 
-        $url .= implode('&', $new_query_parts);
+        $all_query_params = array_merge($existing_query_params, $params);
+        $new_query_param_string = http_build_query($all_query_params);
 
-        return $url;
+        return $url . '?' . $new_query_param_string;
     }
 
 


### PR DESCRIPTION
Usage example: 
```twig
<script src="{{ 'SKIN/assets/js/example.js'|busty }}"></script>
```
or
```twig
<script src="{{ busty('SKIN/assets/js/example.js') }}"></script>
```

There is also an optional `sub_directory` argument for extra flexibility. For example, if `Kohana::config('core.site_domain')` is set to "/", but the `skin/` directory lives within a sub-directory such as `app/`, then you can provide this:
```twig
<script src="{{ 'SKIN/assets/js/example.js'|busty('app/') }}"></script>
```
or
```twig
<script src="{{ busty('SKIN/assets/js/example.js', 'app/') }}"></script>
```

The end result is a URL with a query string parameter of `_v` and the file's timestamp. The logic assumes that the URL provided does not already have query string parameters.