### PR TITLE
Populates form errors from ValidationException, when thrown from `model->save()`

### DIFF
--- a/src/sprout/Helpers/Validator.php
+++ b/src/sprout/Helpers/Validator.php
@@ -492,4 +492,19 @@ class Validator
         return $out;
     }
 
+
+    /**
+     * Populates form field errors from ValidationException
+     *
+     * @param ValidationException $exception
+     * @return void
+     */
+    public function fromValidationException(ValidationException $exception): void
+    {
+        foreach ($exception->getErrors() as $field => $msgs) {
+            foreach ($msgs as $msg) {
+                $this->addFieldError($field, $msg);
+            }
+        }
+    }
 }


### PR DESCRIPTION
Allows mixed validation in a controller's form submission action.

Usage:

```php
$valid = new Validator($_POST);
// other validation

$business->update($_POST);

try {
    $business->save();
} catch (ValidationException $ex) {
    $valid->fromValidationException($ex);
}

if ($valid->hasErrors()) {
    $_SESSION['example']['field_errors'] = $valid->getFieldErrors();
    $valid->createNotifications();
    Url::redirect("business/register/details/{$uid}");
}
```