### PR TITLE
Adds `updateFiltered` method to Record class

### DIFF
--- a/src/sprout/Helpers/Record.php
+++ b/src/sprout/Helpers/Record.php
@@ -70,4 +70,24 @@ abstract class Record extends Collection implements PdbModelInterface
         unset($data['id']);
         return $data;
     }
+
+
+    /**
+     * Populates record from given config, filtering out non record properties.
+     * Useful for use with POST data.
+     *
+     * @param iterable $config
+     * @return void
+     */
+    public function updateFiltered($config): void
+    {
+        $filtered = [];
+
+        foreach ($this->getSaveData() as $field => $unused)
+        {
+            if (isSet($config[$field])) $filtered[$field] = $config[$field];
+        }
+
+        $this->update($filtered);
+    }
 }


### PR DESCRIPTION
Prevents the model throwing errors when post data contains undeclared model properties. This PR might be moot as Gwilyn mention there's already a fix _somewhere_.

Builds upon `update()` by filtering out non record properties from given config, allowing for use with POST data

Usage:

```php
$business->updateFiltered($_POST);
$business->save();
```