### PR TITLE
Adds method to FileModel to rename the physical file

### DIFF
--- a/src/sprout/Models/FileModel.php
+++ b/src/sprout/Models/FileModel.php
@@ -227,4 +227,19 @@ class FileModel extends Model
             if ($transact and $pdb->inTransaction()) $pdb->rollback();
         }
     }
+
+
+    /**
+     * Renames physical file
+     *
+     * @param string $filename
+     * @return bool True on success
+     */
+    public function renameOnDisk(string $filename): bool
+    {
+        $src = File::baseDir() . $this->filename;
+        $this->filename = $filename;
+
+        return File::moveUpload($src, $this->filename);
+    }
 }

--- a/src/sprout/Models/FileModel.php
+++ b/src/sprout/Models/FileModel.php
@@ -235,7 +235,7 @@ class FileModel extends Model
      * @param string $filename
      * @return bool True on success
      */
-    public function renameOnDisk(string $filename): bool
+    public function moveFile(string $filename): bool
     {
         $src = File::baseDir() . $this->filename;
         $this->filename = $filename;


### PR DESCRIPTION
Example is to obfuscate an uploaded file. In this example the new filename can't be generated till we have the file's id.

```php
$liability_file = FileModel::fromUpload('liability');
$new_filename = sprintf(
    '%s.%s',
    Pdb::generateUid('files', $liability_file->id),
    File::getExt($liability_file->filename)
);
$liability_file->renameOnDisk($new_filename);
$liability_file->save();
```

