### PR TITLE
Feat/model rules

### DIFF
--- a/src/sprout/Helpers/Model.php
+++ b/src/sprout/Helpers/Model.php
@@ -15,9 +15,12 @@ namespace Sprout\Helpers;
 use Exception;
 use karmabunny\kb\CachedHelperTrait;
 use karmabunny\kb\EncryptInterface;
+use karmabunny\kb\RulesClassValidator;
+use karmabunny\kb\RulesValidatorInterface;
 use karmabunny\kb\RulesValidatorTrait;
 use karmabunny\kb\Validates;
 use karmabunny\kb\ValidationException;
+use Kohana;
 use PDOException;
 
 /**
@@ -126,6 +129,19 @@ abstract class Model extends Record implements Validates
     protected function _getEncrypt(): EncryptInterface
     {
         return Sprout::getEncrypt($this->getTableName());
+    }
+
+
+    /**
+     *
+     * @return RulesValidatorInterface
+     */
+    public function getValidator(): RulesValidatorInterface
+    {
+        $validator = new RulesClassValidator($this);
+        $rules = Kohana::config('models.rules');
+        $validator->setValidators($rules);
+        return $validator;
     }
 
 

--- a/src/sprout/Helpers/Rules/AllInSetRule.php
+++ b/src/sprout/Helpers/Rules/AllInSetRule.php
@@ -1,0 +1,52 @@
+<?php
+/*
+ * Copyright (C) 2017 Karmabunny Pty Ltd.
+ *
+ * This file is a part of SproutCMS.
+ *
+ * SproutCMS is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU General Public License as published by the Free Software Foundation, either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * For more information, visit <http://getsproutcms.com>.
+ */
+namespace Sprout\Helpers\Rules;
+
+use karmabunny\kb\ValidationException;
+
+/**
+ * Checks all selected values belong to a database SET definition.
+ *
+ * @package Sprout\Helpers\Rules
+ */
+class AllInSetRule extends BaseModelRule
+{
+
+    /** @inheritdoc */
+    public function validateOne(string $field, $value)
+    {
+        if (!$this->model) {
+            return;
+        }
+
+        if (!is_array($value)) {
+            $value = $value ? [$value] : [];
+        }
+
+        $pdb = $this->model->getConnection();
+        $table = $this->model->getTableName();
+        $set = $pdb->extractEnumArr($table, $field);
+
+        $errors = [];
+
+        foreach ($value as $item) {
+            if (!in_array($item, $set)) {
+                $errors[] = $item;
+            }
+        }
+
+        if ($errors) {
+            throw new ValidationException('Invalid values: ' . implode(', ', $errors));
+        }
+    }
+}

--- a/src/sprout/Helpers/Rules/AllInTableRule.php
+++ b/src/sprout/Helpers/Rules/AllInTableRule.php
@@ -1,0 +1,59 @@
+<?php
+/*
+ * Copyright (C) 2017 Karmabunny Pty Ltd.
+ *
+ * This file is a part of SproutCMS.
+ *
+ * SproutCMS is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU General Public License as published by the Free Software Foundation, either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * For more information, visit <http://getsproutcms.com>.
+ */
+namespace Sprout\Helpers\Rules;
+
+use karmabunny\kb\ValidationException;
+
+/**
+ * Checks all selected values match IDs in a corresponding table.
+ *
+ * @package Sprout\Helpers\Rules
+ */
+class AllInTableRule extends BaseModelRule
+{
+
+    /** @inheritdoc */
+    public function validateOne(string $field, $value)
+    {
+        if (!$this->model) {
+            return;
+        }
+
+        $pdb = $this->model->getConnection();
+        $table = $this->model->getTableName();
+
+        // Extract IDs from autofill list submissions
+        // This is a stop-gap measure until autofill list is reworked to only submit ID values
+        foreach ($value as &$item) {
+            if (!is_array($item)) continue;
+
+            if (!isset($item['id'])) {
+                throw new ValidationException('Invalid value');
+            }
+
+            $item = $item['id'];
+        }
+        unset($item);
+
+        $value = array_unique($value);
+
+        $found_ids = $pdb->find($table)
+            ->where([['id', 'IN', $value]])
+            ->select('id')
+            ->column();
+
+        if (count($value) != count($found_ids)) {
+            throw new ValidationException('Invalid value');
+        }
+    }
+}

--- a/src/sprout/Helpers/Rules/BaseModelRule.php
+++ b/src/sprout/Helpers/Rules/BaseModelRule.php
@@ -1,0 +1,44 @@
+<?php
+/*
+ * Copyright (C) 2017 Karmabunny Pty Ltd.
+ *
+ * This file is a part of SproutCMS.
+ *
+ * SproutCMS is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU General Public License as published by the Free Software Foundation, either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * For more information, visit <http://getsproutcms.com>.
+ */
+namespace Sprout\Helpers\Rules;
+
+use karmabunny\kb\BaseRule;
+use karmabunny\pdb\PdbModelInterface;
+
+/**
+ *
+ * @package Sprout\Helpers\Rules
+ */
+abstract class BaseModelRule extends BaseRule
+{
+
+    /** @var PdbModelInterface|null */
+    public $model;
+
+
+    /** @inheritdoc */
+    public function validate($data)
+    {
+        if (!$data instanceof PdbModelInterface) {
+            return;
+        }
+
+        try {
+            $this->model = $data;
+            parent::validate($data);
+        }
+        finally {
+            $this->model = null;
+        }
+    }
+}

--- a/src/sprout/Helpers/Rules/InEnumRule.php
+++ b/src/sprout/Helpers/Rules/InEnumRule.php
@@ -1,0 +1,41 @@
+<?php
+/*
+ * Copyright (C) 2017 Karmabunny Pty Ltd.
+ *
+ * This file is a part of SproutCMS.
+ *
+ * SproutCMS is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU General Public License as published by the Free Software Foundation, either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * For more information, visit <http://getsproutcms.com>.
+ */
+namespace Sprout\Helpers\Rules;
+
+use karmabunny\kb\ValidationException;
+
+/**
+ * Validates a value meant for an ENUM field
+ *
+ * @package Sprout\Helpers\Rules
+ */
+class InEnumRule extends BaseModelRule
+{
+
+    /** @inheritdoc */
+    public function validateOne(string $field, $value)
+    {
+        if (!$this->model) {
+            return;
+        }
+
+        $pdb = $this->model->getConnection();
+        $table = $this->model->getTableName();
+
+        $enum = $pdb->extractEnumArr($table, $field);
+
+        if (!in_array($value, $enum)) {
+            throw new ValidationException("Invalid value");
+        }
+    }
+}

--- a/src/sprout/Helpers/Rules/InTableRule.php
+++ b/src/sprout/Helpers/Rules/InTableRule.php
@@ -1,0 +1,41 @@
+<?php
+/*
+ * Copyright (C) 2017 Karmabunny Pty Ltd.
+ *
+ * This file is a part of SproutCMS.
+ *
+ * SproutCMS is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU General Public License as published by the Free Software Foundation, either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * For more information, visit <http://getsproutcms.com>.
+ */
+namespace Sprout\Helpers\Rules;
+
+use karmabunny\kb\ValidationException;
+
+/**
+ * Checks a value matches an ID in a corresponding table.
+ *
+ * @package Sprout\Helpers\Rules
+ */
+class InTableRule extends BaseModelRule
+{
+
+    /** @inheritdoc */
+    public function validateOne(string $field, $value)
+    {
+        if (!$this->model) {
+            return;
+        }
+
+        $pdb = $this->model->getConnection();
+        $table = $this->model->getTableName();
+
+        $exists = $pdb->find($table)->where(['id' => $value])->exists();
+
+        if (!$exists) {
+            throw new ValidationException('Invalid value');
+        }
+    }
+}

--- a/src/sprout/Helpers/Rules/PasswordRule.php
+++ b/src/sprout/Helpers/Rules/PasswordRule.php
@@ -1,0 +1,61 @@
+<?php
+/*
+ * Copyright (C) 2017 Karmabunny Pty Ltd.
+ *
+ * This file is a part of SproutCMS.
+ *
+ * SproutCMS is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU General Public License as published by the Free Software Foundation, either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * For more information, visit <http://getsproutcms.com>.
+ */
+namespace Sprout\Helpers\Rules;
+
+use karmabunny\kb\BaseRule;
+use karmabunny\kb\ValidationException;
+use Kohana;
+use Sprout\Helpers\Security;
+
+/**
+ * Validate password by length, type of characters, and list of common passwords
+ *
+ * @package Sprout\Helpers\Rules
+ */
+class PasswordRule extends BaseRule
+{
+
+    public $length = 6;
+
+    public $classes = 2;
+
+    public $bad_list = true;
+
+
+    public function __construct()
+    {
+        $this->length = (int) Kohana::config('sprout.password_length');
+        $this->length = max(6, $this->length);
+
+
+        if (is_int($classes = Kohana::config('sprout.password_classes'))) {
+            $this->classes = $classes;
+        }
+
+        if (is_bool($bad_list = Kohana::config('sprout.password_bad_list'))) {
+            $this->bad_list = $bad_list;
+        }
+    }
+
+
+    /** @inheritdoc */
+    public function validateOne(string $field, $value)
+    {
+        $errors = Security::passwordComplexity($value, $this->length, $this->classes, $this->bad_list);
+
+        if (count($errors) > 0) {
+            throw (new ValidationException)
+                ->addErrors($errors);
+        }
+    }
+}

--- a/src/sprout/Helpers/Rules/UniqueValueRule.php
+++ b/src/sprout/Helpers/Rules/UniqueValueRule.php
@@ -1,0 +1,63 @@
+<?php
+/*
+ * Copyright (C) 2017 Karmabunny Pty Ltd.
+ *
+ * This file is a part of SproutCMS.
+ *
+ * SproutCMS is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU General Public License as published by the Free Software Foundation, either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * For more information, visit <http://getsproutcms.com>.
+ */
+namespace Sprout\Helpers\Rules;
+
+use karmabunny\kb\ValidationException;
+
+/**
+ * Checks that a unique value doesn't already exist in the database, e.g. a username or email address.
+ * This is to give a friendlier frontend to DB errors pertaining to UNIQUE constraints.
+ *
+ * N.B. this function uses LIKE for case-insensitive matching, so it's even stricter than a UNIQUE constraint.
+ *
+ * @package Sprout\Helpers\Rules
+ */
+class UniqueValueRule extends BaseModelRule
+{
+
+    public $message = 'Must be a unique value';
+
+
+    /** @inheritdoc */
+    public function parse(array $ruleset)
+    {
+        parent::parse($ruleset);
+
+        if ($message = $ruleset['message'] ?? null) {
+            $this->message = $message;
+        }
+    }
+
+
+    /** @inheritdoc */
+    public function validateOne(string $field, $value)
+    {
+        if (!$this->model) {
+            return;
+        }
+
+        $pdb = $this->model->getConnection();
+        $table = $this->model->getTableName();
+
+        $query = $pdb->find($table)
+            ->where([[$field, 'LIKE', $value]]);
+
+        if (property_exists($this->model, 'id')) {
+            $query->andWhere([['id', '!=', $this->model->id]]);
+        }
+
+        if ($query->exists()) {
+            throw new ValidationException($this->message);
+        }
+    }
+}

--- a/src/sprout/config/models.php
+++ b/src/sprout/config/models.php
@@ -1,0 +1,36 @@
+<?php
+
+$config['rules'] = [
+    karmabunny\kb\rules\RequiredRule::class,
+    karmabunny\kb\rules\AllInArrayRule::class,
+    karmabunny\kb\rules\AllMatchRule::class,
+    karmabunny\kb\rules\AllUniqueRule::class,
+    karmabunny\kb\rules\BinaryRule::class,
+    karmabunny\kb\rules\DateRangeRule::class,
+    karmabunny\kb\rules\EmailRule::class,
+    karmabunny\kb\rules\InArrayRule::class,
+    karmabunny\kb\rules\Ipv4AddrOrCidrRule::class,
+    karmabunny\kb\rules\Ipv4AddrRule::class,
+    karmabunny\kb\rules\Ipv4CidrRule::class,
+    karmabunny\kb\rules\LengthRule::class,
+    karmabunny\kb\rules\MysqlDateRule::class,
+    karmabunny\kb\rules\MysqlDateTimeRule::class,
+    karmabunny\kb\rules\MysqlTimeRule::class,
+    karmabunny\kb\rules\NumericRule::class,
+    karmabunny\kb\rules\OneRequiredRule::class,
+    karmabunny\kb\rules\PhoneRule::class,
+    karmabunny\kb\rules\PositiveIntRule::class,
+    karmabunny\kb\rules\ProseTextRule::class,
+    karmabunny\kb\rules\RangeRule::class,
+    karmabunny\kb\rules\RegexRule::class,
+
+    // New password rule.
+    Sprout\Helpers\Rules\PasswordRule::class,
+
+    // Pdb/model based rules.
+    Sprout\Helpers\Rules\AllInSetRule::class,
+    Sprout\Helpers\Rules\AllInTableRule::class,
+    Sprout\Helpers\Rules\InEnumRule::class,
+    Sprout\Helpers\Rules\InTableRule::class,
+    Sprout\Helpers\Rules\UniqueValueRule::class,
+];

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use karmabunny\kb\Uuid;
+use karmabunny\kb\ValidationException;
 use karmabunny\pdb\Exceptions\ConnectionException;
 use karmabunny\pdb\Models\PdbRawCondition;
 use karmabunny\pdb\PdbParser;
@@ -44,10 +45,12 @@ class ModelTest extends TestCase
         // A new model.
         $model = new ModelItem();
         $model->name = 'sprout test';
+        $model->status = 'pending';
 
         $expected = [
             'date_added',
             'name',
+            'status',
             'uid',
         ];
 
@@ -61,7 +64,7 @@ class ModelTest extends TestCase
         $this->assertNull($model->date_added);
 
         // Pdo is opened here.
-        $this->assertTrue($model->save());
+        $this->assertTrue($model->save(false));
         $this->assertGreaterThan(0, $model->id);
 
         sleep(1);
@@ -77,7 +80,7 @@ class ModelTest extends TestCase
         usleep(500 * 1000);
 
         $model->name = 'something else';
-        $this->assertTrue($model->save());
+        $this->assertTrue($model->save(false));
 
         // Some things change, others stay the same.
         $this->assertEquals($added, $model->date_added);
@@ -91,5 +94,62 @@ class ModelTest extends TestCase
         $this->assertEquals($model->uid, $other->uid);
         $this->assertEquals($model->date_added, $other->date_added);
         $this->assertEquals($model->name, $other->name);
+    }
+
+
+
+    public function testModelRules()
+    {
+        // A new model.
+        $model = new ModelItem();
+        $model->name = 'sprout test';
+        $model->status = 'pending';
+
+        $ok = $model->save();
+        $this->assertTrue($ok);
+
+        // Mess it up a bit.
+        $model->id = 0;
+        $model->name = '';
+        $model->status = 'lol what';
+        $errors = $model->valid();
+
+        $this->assertNotTrue($errors);
+        $this->assertArrayHasKey('uid', $errors);
+        $this->assertStringContainsStringIgnoringCase('unique', $errors['uid'][0]);
+
+        $this->assertArrayHasKey('name', $errors);
+        $this->assertArrayHasKey('required', $errors['name']);
+
+        $this->assertArrayHasKey('status', $errors);
+        $this->assertStringContainsStringIgnoringCase('invalid', $errors['status'][0]);
+
+        // Still not OK, but we're past the required rule.
+        $model->name = '1234';
+        $errors = $model->valid();
+
+        $this->assertArrayHasKey('name', $errors);
+        $this->assertArrayNotHasKey('required', $errors['name']);
+        $this->assertStringContainsStringIgnoringCase('shorter', $errors['name'][0]);
+
+        // One more for luck.
+        $other = new ModelItem();
+        $other->name = 'sprout test';
+        $other->status = 'ready';
+
+        try {
+            $other->save();
+            $this->fail('Expected validation error');
+
+        } catch (ValidationException $exception) {
+            $errors = $exception->getErrors();
+            $this->assertArrayHasKey('name', $errors);
+            $this->assertStringContainsStringIgnoringCase('unique', $errors['name'][0]);
+            $this->assertStringContainsStringIgnoringCase('name', $exception->getMessage());
+        }
+
+        // Fix it.
+        $other->name = 'other test';
+        $other->save();
     }
 }

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -61,10 +61,12 @@ class ModelTest extends TestCase
         $this->assertTrue($model->save());
         $this->assertGreaterThan(0, $model->id);
 
+        sleep(1);
+
         $this->assertNotEquals(Uuid::NIL, $model->uid);
         $this->assertTrue(Uuid::valid($model->uid, 5));
 
-        $this->assertGreaterThanOrEqual(date('Y-m-d H:i:s'), $model->date_added);
+        $this->assertLessThanOrEqual(date('Y-m-d H:i:s'), $model->date_added);
 
         $uid = $model->uid;
         $added = $model->date_added;

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -2,6 +2,7 @@
 
 use karmabunny\kb\Uuid;
 use karmabunny\pdb\Exceptions\ConnectionException;
+use karmabunny\pdb\Models\PdbRawCondition;
 use karmabunny\pdb\PdbParser;
 use karmabunny\pdb\PdbSync;
 use PHPUnit\Framework\TestCase;
@@ -33,6 +34,8 @@ class ModelTest extends TestCase
         $struct->sanityCheck();
 
         $sync->updateDatabase($struct);
+
+        $pdb->delete(ModelItem::getTableName(), [new PdbRawCondition('1=1')]);
     }
 
 

--- a/tests/Models/ModelItem.php
+++ b/tests/Models/ModelItem.php
@@ -16,11 +16,25 @@ class ModelItem extends Model
 
 
     /** @var string */
-    public $name;
-
-    /** @var string */
     public $uid;
 
     /** @var string */
     public $date_added;
+
+    /** @var string */
+    public $name;
+
+    /** @var string */
+    public $status;
+
+
+    public function rules(): array
+    {
+        return [
+            ['required' => ['name', 'status']],
+            ['uniqueValue' => ['name', 'uid']],
+            ['length' => ['name', 'min' => 5]],
+            ['inEnum' => ['status']],
+        ];
+    }
 }

--- a/tests/config/db_struct.xml
+++ b/tests/config/db_struct.xml
@@ -10,6 +10,12 @@
 
         <column name="name" type="TEXT" allownull="0"/>
 
+        <column name="status" type="ENUM(xml)">
+            <val>pending</val>
+            <val>ready</val>
+            <val>error</val>
+        </column>
+
         <primary>
             <col name="id"/>
         </primary>


### PR DESCRIPTION
This builds on this branch: https://github.com/Karmabunny/kbphp/pull/13

Class based rules are significantly more powerful and composable than what we have from the validity class.

For example:

```php
// OLD
'uniqueValue' => ['email', 'args' => ['users', 'email', 0, 'Email already registered']],

// NEW
'uniqueValue' => ['email', 'message' => 'Email already registered'],
```

Here a model already knows it's table name, so it's silly that we need to provide it again. The rule parser also means we can be more descriptive about each argument instead of a generic 'args' array.

In addition, multi-check rules no longer need `'multi' => true`. Each validator is given the full list of fields and values, so is able to decide if it wants to perform single or multi-checks.

### Testing

Run the tests yo.
```
 % composer test -- --filter ModelTest
 ```

### Migration

Unfortunately, there IS breaking change to rulesets and required a migration set. There's lots of backwards compat for nested rulesets and args. But the args themselves are different.

On second thought -  each validator could provide the 'args' backwards compat themselves. So perhaps we'll do that and retain that backwards compat.
