### PR TITLE
Feat/neon forms

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
         "karmabunny/rdb": "^1.20",
         "karmabunny/router": "^2.7.12",
         "karmabunny/visor": "^1.0",
+        "nette/neon": "^3.4",
         "nyholm/psr7": "^1.6",
         "openai-php/client": "^0.10.1",
         "phpmailer/phpmailer": "^6.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "45248c07a27169635987b6199438d3e3",
+    "content-hash": "a8140743eb4ccdd6790f292db5b811a4",
     "packages": [
         {
             "name": "colinmollenhour/credis",
@@ -815,6 +815,74 @@
                 "source": "https://github.com/Masterminds/html5-php/tree/2.9.0"
             },
             "time": "2024-03-31T07:05:07+00:00"
+        },
+        {
+            "name": "nette/neon",
+            "version": "v3.4.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/neon.git",
+                "reference": "3411aa86b104e2d5b7e760da4600865ead963c3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/neon/zipball/3411aa86b104e2d5b7e760da4600865ead963c3c",
+                "reference": "3411aa86b104e2d5b7e760da4600865ead963c3c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": "8.0 - 8.4"
+            },
+            "require-dev": {
+                "nette/tester": "^2.4",
+                "phpstan/phpstan": "^1.0",
+                "tracy/tracy": "^2.7"
+            },
+            "bin": [
+                "bin/neon-lint"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.4-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0-only",
+                "GPL-3.0-only"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "https://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "https://nette.org/contributors"
+                }
+            ],
+            "description": "🍸 Nette NEON: encodes and decodes NEON file format.",
+            "homepage": "https://ne-on.org",
+            "keywords": [
+                "export",
+                "import",
+                "neon",
+                "nette",
+                "yaml"
+            ],
+            "support": {
+                "issues": "https://github.com/nette/neon/issues",
+                "source": "https://github.com/nette/neon/tree/v3.4.4"
+            },
+            "time": "2024-10-04T22:00:08+00:00"
         },
         {
             "name": "nyholm/psr7",

--- a/src/sprout/Helpers/Neon/BlockArrayNode.php
+++ b/src/sprout/Helpers/Neon/BlockArrayNode.php
@@ -1,0 +1,69 @@
+<?php
+/*
+ * Copyright (C) 2024 Karmabunny Pty Ltd.
+ *
+ * This file is a part of SproutCMS.
+ *
+ * SproutCMS is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU General Public License as published by the Free Software Foundation, either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * For more information, visit <http://getsproutcms.com>.
+ *
+ * This file is adapted from the Nette Framework (https://nette.org)
+ * Copyright (c) 2004 David Grudl (https://davidgrudl.com)
+ */
+
+declare(strict_types=1);
+
+namespace Sprout\Helpers\Neon;
+
+use Nette\Neon\Node\ArrayNode;
+
+/** @internal */
+final class BlockArrayNode extends ArrayNode
+{
+	public function __construct(
+		public string $indentation = '',
+	) {
+	}
+
+
+	/** @inheritdoc */
+	public function toString(): string
+	{
+		if (count($this->items) === 0) {
+			return '[]';
+		}
+
+		$res = '';
+
+		foreach ($this->items as $item) {
+			$v = $item->value->toString();
+
+			if ($item->key) {
+				$res .= $item->key->toString() . ':';
+
+				if ($item->value instanceof BlockArrayNode and $item->value->items) {
+					$v = preg_replace('#^(?=.)#m', $this->indentation, $v);
+					$res .= "\n" . $v . (substr($v, -2, 1) === "\n" ? '' : "\n");
+				} else if ($item->value instanceof JsonArrayNode and $item->value->items) {
+					$res .= "" . $v . (substr($v, -2, 1) === "\n" ? '' : "\n");
+				} else {
+					$res .= ' ' . $v . "\n";
+				}
+			}
+			else {
+				$res .= substr($this->indentation, 2) . '- ';
+
+				if ($item->value instanceof BlockArrayNode and $item->value->items) {
+					$res .= $v . (substr($v, -2, 1) === "\n" ? '' : "\n");
+				} else {
+					$res .= $v . "\n";
+				}
+			}
+		}
+
+		return $res;
+	}
+}

--- a/src/sprout/Helpers/Neon/Encoder.php
+++ b/src/sprout/Helpers/Neon/Encoder.php
@@ -1,0 +1,121 @@
+<?php
+/*
+ * Copyright (C) 2024 Karmabunny Pty Ltd.
+ *
+ * This file is a part of SproutCMS.
+ *
+ * SproutCMS is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU General Public License as published by the Free Software Foundation, either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * For more information, visit <http://getsproutcms.com>.
+ *
+ * This file is adapted from the Nette Framework (https://nette.org)
+ * Copyright (c) 2004 David Grudl (https://davidgrudl.com)
+ */
+
+declare(strict_types=1);
+
+namespace Sprout\Helpers\Neon;
+
+use Nette\Neon\Entity;
+use Nette\Neon\Lexer;
+use Nette\Neon\Neon;
+use Nette\Neon\Node;
+
+/**
+ * Converts value to NEON format.
+ *
+ * This is modified to perform preferred formatting for NEON forms.
+ */
+class Encoder
+{
+	public string $indentation = "    ";
+
+	public array $jsonKeys = [
+		'validate',
+		'args',
+	];
+
+
+	/**
+	 * Returns the NEON representation of a value.
+	 */
+	public function encode(mixed $val): string
+	{
+		$node = $this->valueToNode(null, $val);
+		return $node->toString();
+	}
+
+
+	public function valueToNode(mixed $key, mixed $val): Node
+	{
+		if ($val instanceof \DateTimeInterface) {
+			return new Node\LiteralNode($val);
+
+		} elseif ($val instanceof Entity && $val->value === Neon::Chain) {
+			$node = new Node\EntityChainNode;
+			foreach ($val->attributes as $entity) {
+				$node->chain[] = $this->valueToNode(null, $entity);
+			}
+
+			return $node;
+
+		} elseif ($val instanceof Entity) {
+			return new Node\EntityNode(
+				$this->valueToNode(null, $val->value),
+				$this->arrayToNodes($val->attributes),
+			);
+
+		} elseif (is_object($val) || is_array($val)) {
+			if ($key and in_array($key, $this->jsonKeys)) {
+				$node = new JsonArrayNode($this->indentation);
+				$node->items = $val;
+				return $node;
+			}
+
+			$node = new BlockArrayNode;
+			$node->items = $this->arrayToNodes($val);
+			return $node;
+
+		} elseif (is_string($val)) {
+			// Always add delimiters for strings.
+			return new Node\StringNode($val);
+
+		} else {
+			return new Node\LiteralNode($val);
+		}
+	}
+
+
+	/** @return Node\ArrayItemNode[] */
+	private function arrayToNodes(mixed $val): array
+	{
+		$res = [];
+		$counter = 0;
+		$hide = true;
+		foreach ($val as $k => $v) {
+			$res[] = $item = new Node\ArrayItemNode;
+			$item->key = null;
+
+			// Retain conditional delimiting for keys.
+			if (!($hide && $k === $counter)) {
+				$item->key = Lexer::requiresDelimiters($k)
+					? new Node\StringNode($k)
+					: new Node\LiteralNode($k);
+			}
+
+			$item->value = self::valueToNode($k, $v);
+			if ($item->value instanceof BlockArrayNode) {
+				$item->value->indentation = $this->indentation;
+			}
+
+			if ($hide && is_int($k)) {
+				$hide = $k === $counter;
+				$counter = max($k + 1, $counter);
+			}
+		}
+
+		return $res;
+	}
+}

--- a/src/sprout/Helpers/Neon/JsonArrayNode.php
+++ b/src/sprout/Helpers/Neon/JsonArrayNode.php
@@ -1,0 +1,65 @@
+<?php
+/*
+ * Copyright (C) 2024 Karmabunny Pty Ltd.
+ *
+ * This file is a part of SproutCMS.
+ *
+ * SproutCMS is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU General Public License as published by the Free Software Foundation, either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * For more information, visit <http://getsproutcms.com>.
+ *
+ * This file is adapted from the Nette Framework (https://nette.org)
+ * Copyright (c) 2004 David Grudl (https://davidgrudl.com)
+ */
+
+declare(strict_types=1);
+
+namespace Sprout\Helpers\Neon;
+
+use Nette\Neon\Node;
+
+/** @internal */
+final class JsonArrayNode extends Node
+{
+
+	public array $items = [];
+
+
+	public function __construct(
+		public string $indentation = '',
+	) {
+	}
+
+
+	/** @inheritdoc */
+	public function toString(): string
+	{
+		if (count($this->items) === 0) {
+			return '[]';
+		}
+
+		$isList = array_is_list($this->items);
+		$res = '';
+
+		foreach ($this->items as $key => $item) {
+			$v = json_encode($item);
+
+			if ($isList) {
+				$res .= "\n" . substr($this->indentation, 2) . '- ' . $v;
+			} else {
+				$res .= "\n{$this->indentation}{$key}: {$v}";
+			}
+		}
+
+		return $res;
+	}
+
+
+	/** @inheritdoc */
+	public function toValue(): mixed
+	{
+		return $this->items;
+	}
+}

--- a/src/sprout/Helpers/Neon/Neon.php
+++ b/src/sprout/Helpers/Neon/Neon.php
@@ -1,0 +1,49 @@
+<?php
+/*
+ * Copyright (C) 2024 Karmabunny Pty Ltd.
+ *
+ * This file is a part of SproutCMS.
+ *
+ * SproutCMS is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU General Public License as published by the Free Software Foundation, either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * For more information, visit <http://getsproutcms.com>.
+ *
+ * This file is adapted from the Nette Framework (https://nette.org)
+ * Copyright (c) 2004 David Grudl (https://davidgrudl.com)
+ */
+
+declare(strict_types=1);
+
+namespace Sprout\Helpers\Neon;
+
+use Nette\Neon\Decoder;
+
+/**
+ * Simple parser & generator for Nette Object Notation.
+ * @see https://ne-on.org
+ */
+final class Neon
+{
+
+	/**
+	 * Returns value converted to NEON.
+	 */
+	public static function encode(mixed $value, string $indentation = "    "): string
+	{
+		$encoder = new Encoder;
+		$encoder->indentation = $indentation;
+		return $encoder->encode($value);
+	}
+
+
+	/**
+	 * Converts given NEON to PHP value.
+	 */
+	public static function decode(string $input): mixed
+	{
+		$decoder = new Decoder;
+		return $decoder->decode($input);
+	}
+}

--- a/src/sprout/module_template/admin_edit.example.neon
+++ b/src/sprout/module_template/admin_edit.example.neon
@@ -1,0 +1,63 @@
+tab-details:
+  - field:
+    name: 'first_name'
+    label: 'Given name'
+    attrs:
+        id: 'admin-noobcakes-firstname'
+        placeholder: 'Frank'
+        data-xxx: ''
+
+    display: 'Fb::text'
+
+    # Items are usually for radio/dropdown, but will be passed as an arg to any fb::-style function
+    # Radio/Dropdown (inline)
+    items:
+        a: 'A'
+        b: 'B'
+
+    # Radio/Dropdown (lookup)
+    items2: 'MyHelper::myItems'
+    required: true
+
+    # don't save display values
+    ignore: true
+    validate:
+      - {"func":"Val::personName"}
+      - {"func":"Val::len","args":[1,20]}
+      - {"func":"Slug::validateUnique","for":["edit"]}
+
+  - checkboxes:
+    label: ''
+    items:
+        name: 'label'
+        name2: 'label2'
+
+  - heading: ''
+
+  - html: '<p>I like peanuts</p>'
+
+  - group:
+      - field: '_'
+      - field: '_'
+
+  - custom:
+    display:
+        func: 'MyClass:myFunc'
+        args:
+          - "_"
+    save:
+        func_: '// Takes an array of field => val, which fn modifies'
+        func: 'MyClass:myFunc'
+        args:
+          - "_"
+
+  - multiedit:
+    table: 'event_dates'
+    where: 'Events::getFutureCondition'
+    single: 'Date'
+    items:
+      - field: '_'
+      - field: '_'
+
+second_tab: []
+Categories: 'categories'

--- a/src/sprout/module_template/has_categories/SNAME_admin_edit.json
+++ b/src/sprout/module_template/has_categories/SNAME_admin_edit.json
@@ -1,6 +1,0 @@
-{
-    "Details": [
-FIELDS_JSON
-    ],
-    "Categories": "categories"
-}

--- a/src/sprout/module_template/has_categories/SNAME_admin_edit.neon
+++ b/src/sprout/module_template/has_categories/SNAME_admin_edit.neon
@@ -1,0 +1,4 @@
+Details:
+FIELDS_NEON
+
+Categories: categories

--- a/src/sprout/module_template/list/SNAME_admin_edit.json
+++ b/src/sprout/module_template/list/SNAME_admin_edit.json
@@ -1,5 +1,0 @@
-{
-    "Details": [
-FIELDS_JSON
-    ]
-}

--- a/src/sprout/module_template/list/SNAME_admin_edit.neon
+++ b/src/sprout/module_template/list/SNAME_admin_edit.neon
@@ -1,0 +1,2 @@
+Details:
+FIELDS_NEON

--- a/src/sprout/module_template/tree/SNAME_admin_edit.json
+++ b/src/sprout/module_template/tree/SNAME_admin_edit.json
@@ -1,5 +1,0 @@
-{
-    "Details": [
-FIELDS_JSON
-    ]
-}

--- a/src/sprout/module_template/tree/SNAME_admin_edit.neon
+++ b/src/sprout/module_template/tree/SNAME_admin_edit.neon
@@ -1,0 +1,2 @@
+Details:
+FIELDS_NEON

--- a/tools/migrate_forms.php
+++ b/tools/migrate_forms.php
@@ -1,0 +1,38 @@
+<?php
+
+use Nette\Neon\Neon;
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+$path = $argv[1] ?? null;
+
+if (empty($path)) {
+    echo "Usage: php tools/migrate_forms.php <path/to/json>\n";
+    exit(1);
+}
+
+if (!is_file($path)) {
+    echo "Error: path not found.\n";
+    echo " > {$path}\n";
+    exit(1);
+}
+
+$json = file_get_contents($path);
+$json = json_decode($json, true);
+
+if (!is_array($json)) {
+    echo "Error: invalid json file.\n";
+    echo " > {$path}\n";
+    exit(1);
+}
+
+$neon = Neon::encode($json, true, "    ");
+$neon = preg_replace("/^(\s*)    -\n\s+(html|field|group)/m", '$1  - $2', $neon);
+
+Neon::decode($neon);
+
+$target = preg_replace('/\.json$/', '.neon', $path);
+file_put_contents($target, $neon);
+
+echo "OK: Form migrated.\n";
+echo " > {$target}\n";

--- a/tools/migrate_forms.php
+++ b/tools/migrate_forms.php
@@ -1,6 +1,6 @@
 <?php
 
-use Nette\Neon\Neon;
+use Sprout\Helpers\Neon\Neon;
 
 require dirname(__DIR__) . '/vendor/autoload.php';
 
@@ -26,9 +26,7 @@ if (!is_array($json)) {
     exit(1);
 }
 
-$neon = Neon::encode($json, true, "    ");
-$neon = preg_replace("/^(\s*)    -\n\s+(html|field|group)/m", '$1  - $2', $neon);
-
+$neon = Neon::encode($json);
 Neon::decode($neon);
 
 $target = preg_replace('/\.json$/', '.neon', $path);


### PR DESCRIPTION
JSON forms are a bit gross. They're syntax heavy, can't do comments, has messy diffs, and weirdly _s p a r s e_.

So NEON is a format used by phpstan and is strikingly similar to YAML - but without (most of) the warts that comes with it.

Just get a look at the `admin_edit.example.neon` file. Beautiful.

We've written custom encoder bits because we wanted a tighter format, particularly for migration and module generation. This isn't required - just a nice-to-have.

JSON forms are still supported as a fallback, so there's no breaking changes here. Also included a script to automate conversion if people do want to migrate.