### PR TITLE
Feat/multi upload

### DIFF
--- a/src/media/js/drag_drop_upload.js
+++ b/src/media/js/drag_drop_upload.js
@@ -77,14 +77,15 @@ function init_dragdrop(options) {
         // Remove button is normally created and activated by the upload, but needs to
         // be ready at init time if it already exists (e.g. due to form redirect)
         $(this).closest('.fb-chunked-upload').find('.file-upload__item').each(function(index) {
-            var $button = $(`<button class="file-upload__item__remove" type="button" data-id="${index}"><span class="file-upload__item__remove__text">Remove</span></button>`);
+            var file = $(this).data('file');
+            var $button = $(`<button class="file-upload__item__remove" type="button" data-file="${file}"><span class="file-upload__item__remove__text">Remove</span></button>`);
 
             $(this).children().first().before($button);
 
             $button.click(function() {
                 let $wrapper = $(this).closest('.fb-chunked-upload');
                 let code = $(this).closest('.file-upload__item').data('code');
-                let id = $(this).data('id');
+                let file = $(this).data('file');
 
                 // Delete uploaded file
                 $.ajax({
@@ -101,7 +102,7 @@ function init_dragdrop(options) {
                 remove_file_ref($(this).closest('.file-upload__item'));
 
                 // Mark file deleted
-                $wrapper.find(`.js-delete-notify[data-id="'${id}"]`).val($wrapper.find(`.js-delete-notify[data-id="${id}"]`).attr('data-file'));
+                $wrapper.find(`.js-delete-notify[data-file="${file}"]`).val(1);
 
                 return false;
             });

--- a/src/media/js/drag_drop_upload.js
+++ b/src/media/js/drag_drop_upload.js
@@ -76,14 +76,15 @@ function init_dragdrop(options) {
 
         // Remove button is normally created and activated by the upload, but needs to
         // be ready at init time if it already exists (e.g. due to form redirect)
-        $(this).closest('.fb-chunked-upload').find('.file-upload__item').each(function() {
-            var $button = $('<button class="file-upload__item__remove" type="button"><span class="file-upload__item__remove__text">Remove</span></button>');
+        $(this).closest('.fb-chunked-upload').find('.file-upload__item').each(function(index) {
+            var $button = $(`<button class="file-upload__item__remove" type="button" data-id="${index}"><span class="file-upload__item__remove__text">Remove</span></button>`);
 
             $(this).children().first().before($button);
 
             $button.click(function() {
-                var $wrapper = $(this).closest('.fb-chunked-upload');
-                var code = $(this).closest('.file-upload__item').data('code');
+                let $wrapper = $(this).closest('.fb-chunked-upload');
+                let code = $(this).closest('.file-upload__item').data('code');
+                let id = $(this).data('id');
 
                 // Delete uploaded file
                 $.ajax({
@@ -100,7 +101,7 @@ function init_dragdrop(options) {
                 remove_file_ref($(this).closest('.file-upload__item'));
 
                 // Mark file deleted
-                $wrapper.find('.js-delete-notify').val(1);
+                $wrapper.find(`.js-delete-notify[data-id="'${id}"]`).val($wrapper.find(`.js-delete-notify[data-id="${id}"]`).attr('data-file'));
 
                 return false;
             });

--- a/src/sprout/Helpers/Fb.php
+++ b/src/sprout/Helpers/Fb.php
@@ -503,6 +503,7 @@ class Fb
      * @param array $params Must have 'sess_key' => session key, e.g. 'user-register'.
      *        Data regarding each uploaded file will typically be saved in
      *        $_SESSION['file_uploads'][$params['sess_key']][$name].
+     *        'files' (array): Optional array of filenames to show as uploaded
      *
      *        May also have 'opts' which can contain any of the following:
      *        - 'begin_url' (string)

--- a/src/sprout/Helpers/Fb.php
+++ b/src/sprout/Helpers/Fb.php
@@ -586,6 +586,8 @@ class Fb
 
                 $temp = preg_replace('/[^a-z0-9_\-\.]/i', '', $temp);
 
+                // If we're not replacing a file, we still want to render it.
+                // So sift those out for later.
                 if (!$temp) {
                     $existing_files[] = $friendly;
                     continue;
@@ -613,6 +615,8 @@ class Fb
         }
 
         if (is_array($friendly_vals)) {
+            // Use the sifted files from the vals/temp zip.
+            // Otherwise (if no temp) we can render all form data here.
             $delete_files = $existing_files ?: $friendly_vals;
 
             foreach ($delete_files as $file) {

--- a/src/sprout/Helpers/Fb.php
+++ b/src/sprout/Helpers/Fb.php
@@ -598,8 +598,25 @@ class Fb
 
         if (is_string($friendly_vals)) {
             $files[] = $friendly_vals;
-            $out .= '<input class="js-delete-notify" type="hidden" name="' . Enc::html($name) . '_deleted">';
+
+            $out .= sprintf('<input class="js-delete-notify" type="hidden" data-id="0" data-file="%s" name="%s">',
+                Enc::html($friendly_vals),
+                Enc::html("{$name}_deleted")
+            );
         }
+
+        if (!empty($params['files']) and is_array($params['files'])) {
+            foreach ($params['files'] as $idx => $file) {
+                $files[] = $file;
+
+                $out .= sprintf('<input class="js-delete-notify" type="hidden" data-id="%s" data-file="%s" name="%s">',
+                    Enc::html($idx),
+                    Enc::html($file),
+                    Enc::html("{$name}_deleted[{$idx}]")
+                );
+            }
+        }
+
         foreach ($files as $file) {
             // Temp uploaded files stored in session
             if (is_array($file)) {
@@ -640,7 +657,7 @@ class Fb
         }
 
         // Don't try and save an existing file which is already on disk
-        if (is_string($friendly_vals)) {
+        if (is_string($friendly_vals) or (!empty($params['files']) and is_array($params['files']))) {
             $files = [];
         }
 


### PR DESCRIPTION
Updates `Fb::chunkedUpload` to support multiple previously uploaded files

The original use remains unchanged, allowing for single previously uploaded file to be rendered, deleted.
But now allows for optional list of multiple files to be rendered, deleted.

Use case is to allow front-end user to manage their uploads from another session.

# Original behaviour
Two upload fields, one with single previously uploaded file.
![original behavour](https://github.com/user-attachments/assets/c5353378-3ae0-4368-93af-c392e620d267)

# New behaviour
Single upload field with multiple previously uploaded files
![new behaviour](https://github.com/user-attachments/assets/7bc600c3-60be-4317-8b62-6a41b0214b8a)

