### PR TITLE
Feat/file redirect document

### DIFF
--- a/src/media/js/fb.js
+++ b/src/media/js/fb.js
@@ -54,8 +54,20 @@ var Fb = {
             }
 
             $select.closest('form').submit(function() {
-                if ($select.val()) {
-                    var obj = { 'class': $select.val(), 'data': $wrapper.find('[name=_value]').val() };
+                if ($select.val() == '\\Sprout\\Helpers\\LinkSpecImage') {
+                    var obj = {
+                        'class': $select.val(),
+                        'data': {
+                            'id': $wrapper.find('[name=_value]').val(),
+                            'size': $wrapper.find('[name=_size]').val(),
+                        },
+                    };
+                    $hidden.val(JSON.stringify(obj));
+                } else if ($select.val()) {
+                    var obj = {
+                        'class': $select.val(),
+                        'data': $wrapper.find('[name=_value]').val(),
+                    };
                     $hidden.val(JSON.stringify(obj));
                 } else {
                     $hidden.val('');

--- a/src/media/js/fb.js
+++ b/src/media/js/fb.js
@@ -40,6 +40,7 @@ var Fb = {
 
                 $.post(ROOT + 'admin_ajax/lnk_editor', opts, function(data) {
                     $div.html(data.html);
+                    $div.attr('class', 'lnk-form ' + data.class);
 
                     // Need to activate file selector if 'Document' link type chosen
                     Fb.initAll($div);

--- a/src/sprout/Controllers/Admin/FileAdminController.php
+++ b/src/sprout/Controllers/Admin/FileAdminController.php
@@ -38,6 +38,7 @@ use Sprout\Helpers\Form;
 use Sprout\Helpers\FrontEndSearch;
 use Sprout\Helpers\Image;
 use Sprout\Helpers\Json;
+use Sprout\Helpers\LinkSpecDocument;
 use Sprout\Helpers\Notification;
 use Sprout\Helpers\Pdb;
 use Sprout\Helpers\RefineBar;
@@ -967,24 +968,22 @@ class FileAdminController extends HasCategoriesAdminController
             // Make sure old links still function by adding a redirect from the old file name to the new one
             foreach ($variants as $variant) {
                 $old_path = 'files/' . $original_filename;
-                $new_path = 'file/download/' . $item_id;
+
+                $dest_link_spec = [
+                    'class' => LinkSpecDocument::class,
+                    'data' => ['id' => $item_id],
+                ];
 
                 // For image variants:
                 // convert e.g. 123_blah.jpg to 123_blah.small.jpg
-                // append size to redirect URL, e.g. file/123/small
                 if ($variant) {
                     $old_path = File::getResizeFilename($old_path, $variant);
-                    $new_path .= '/' . $variant;
+                    $dest_link_spec['data']['size'] = $variant;
                 }
-
-                $dest_link_spec = json_encode([
-                    'class' => '\\Sprout\\Helpers\\LinkSpecInternal',
-                    'data' => $new_path,
-                ]);
 
                 $redirect = [
                     'path_exact' => $old_path,
-                    'destination' => $dest_link_spec,
+                    'destination' => json_encode($dest_link_spec),
                     'type' => 'Temporary',
                     'date_added' => Pdb::now(),
                     'date_modified' => Pdb::now(),

--- a/src/sprout/Controllers/Admin/FileAdminController.php
+++ b/src/sprout/Controllers/Admin/FileAdminController.php
@@ -39,6 +39,7 @@ use Sprout\Helpers\FrontEndSearch;
 use Sprout\Helpers\Image;
 use Sprout\Helpers\Json;
 use Sprout\Helpers\LinkSpecDocument;
+use Sprout\Helpers\LinkSpecImage;
 use Sprout\Helpers\Notification;
 use Sprout\Helpers\Pdb;
 use Sprout\Helpers\RefineBar;
@@ -961,8 +962,11 @@ class FileAdminController extends HasCategoriesAdminController
             File::deleteCache($original_filename);
 
             $variants = array('');
+            $linkspec = LinkSpecDocument::class;
+
             if ($file['type'] == FileConstants::TYPE_IMAGE) {
                 $variants = array_merge($variants, array_keys(Kohana::config('file.image_transformations')));
+                $linkspec = LinkSpecImage::class;
             }
 
             // Make sure old links still function by adding a redirect from the old file name to the new one
@@ -970,7 +974,7 @@ class FileAdminController extends HasCategoriesAdminController
                 $old_path = 'files/' . $original_filename;
 
                 $dest_link_spec = [
-                    'class' => '\\' . LinkSpecDocument::class,
+                    'class' => '\\' . $linkspec,
                     'data' => ['id' => $item_id],
                 ];
 

--- a/src/sprout/Controllers/Admin/FileAdminController.php
+++ b/src/sprout/Controllers/Admin/FileAdminController.php
@@ -970,7 +970,7 @@ class FileAdminController extends HasCategoriesAdminController
                 $old_path = 'files/' . $original_filename;
 
                 $dest_link_spec = [
-                    'class' => LinkSpecDocument::class,
+                    'class' => '\\' . LinkSpecDocument::class,
                     'data' => ['id' => $item_id],
                 ];
 

--- a/src/sprout/Controllers/AdminAjaxController.php
+++ b/src/sprout/Controllers/AdminAjaxController.php
@@ -26,6 +26,7 @@ use Sprout\Helpers\Csrf;
 use Sprout\Helpers\Enc;
 use Sprout\Helpers\Form;
 use Sprout\Helpers\FrontEndEntrance;
+use Sprout\Helpers\Html;
 use Sprout\Helpers\Json;
 use Sprout\Helpers\LinkSpec;
 use Sprout\Helpers\Navigation;
@@ -406,6 +407,7 @@ class AdminAjaxController extends Controller
 
         Json::confirm(array(
             'html' => $html,
+            'class' => Sprout::removeNs(get_class($inst)),
         ));
     }
 

--- a/src/sprout/Controllers/AdminAjaxController.php
+++ b/src/sprout/Controllers/AdminAjaxController.php
@@ -364,8 +364,16 @@ class AdminAjaxController extends Controller
         AdminAuth::checkLogin();
 
         $_POST['field'] = trim($_POST['field'] ?? '');
-        $_POST['val'] = trim($_POST['val'] ?? '');
         $_POST['type'] = trim($_POST['type'] ?? '');
+        $_POST['type'] = '\\' . ltrim($_POST['type'], '\\');
+
+        if (empty($_POST['val'])) {
+            $_POST['val'] = '';
+        } else if (is_string($_POST['val'])) {
+            $_POST['val'] = trim($_POST['val']);
+        } else if (is_array($_POST['val'])) {
+            $_POST['val'] = array_map('trim', $_POST['val']);
+        }
 
         if ($_POST['type'] == '') {
             Json::confirm(array(

--- a/src/sprout/Controllers/FileController.php
+++ b/src/sprout/Controllers/FileController.php
@@ -338,7 +338,16 @@ class FileController extends Controller
             if (!preg_match('/^[a-z_]+$/', $size)) {
                 throw new Kohana_404_Exception($filename);
             }
-            $filename = File::getResizeFilename($filename, $size);
+
+            $resize_filename = File::getResizeFilename($filename, $size);
+
+            // Use the resize if we're able.
+            if (
+                !File::exists($resize_filename)
+                and File::createDefaultSize($id, $size)
+            ) {
+                $filename = $resize_filename;
+            }
         }
 
         // TODO not used..?

--- a/src/sprout/Helpers/File.php
+++ b/src/sprout/Helpers/File.php
@@ -1250,20 +1250,16 @@ class File
             WHERE path_exact = ?";
         $dest_spec = Pdb::q($q, ['files/' . $filename], 'val');
 
-        $dest_spec = json_decode($dest_spec, true);
+        $dest_spec = Lnk::parse($dest_spec);
 
-        if (!is_array($dest_spec)) {
-            throw new InvalidArgumentException("Redirect target doesn't match expected value");
-        }
-
-        if ($dest_spec['class'] === LinkSpecDocument::class) {
+        if ($dest_spec['class'] === '\\' . LinkSpecDocument::class) {
             if (is_array($dest_spec['data'])) {
                 $id = (int) $dest_spec['data']['id'];
             } else {
                 $id = (int) $dest_spec['data'];
             }
 
-        } else if ($dest_spec['class'] === LinkSpecInternal::class) {
+        } else if ($dest_spec['class'] === '\\' . LinkSpecInternal::class) {
             // Backwards compat with internal spec.
             $replacement = $dest_spec['data'];
 

--- a/src/sprout/Helpers/File.php
+++ b/src/sprout/Helpers/File.php
@@ -1228,6 +1228,7 @@ class File
 
         return Lnk::url($dest_spec, [
             LinkSpecDocument::class,
+            LinkSpecImage::class,
             LinkSpecInternal::class,
         ]);
     }

--- a/src/sprout/Helpers/File.php
+++ b/src/sprout/Helpers/File.php
@@ -1253,7 +1253,10 @@ class File
 
         $dest_spec = Lnk::parse($dest_spec);
 
-        if ($dest_spec['class'] === '\\' . LinkSpecDocument::class) {
+        if ($dest_spec['class'] === '\\' . LinkSpecImage::class) {
+            $id = (int) $dest_spec['data']['id'];
+
+        } else if ($dest_spec['class'] === '\\' . LinkSpecDocument::class) {
             if (is_array($dest_spec['data'])) {
                 $id = (int) $dest_spec['data']['id'];
             } else {

--- a/src/sprout/Helpers/LinkSpecDocument.php
+++ b/src/sprout/Helpers/LinkSpecDocument.php
@@ -32,8 +32,7 @@ class LinkSpecDocument extends LinkSpec
         if (is_array($specdata)) {
             $id = $specdata['id'] ?? 0;
             $size = $specdata['size'] ?? null;
-        }
-        else {
+        } else {
             $id = (int) $specdata;
             $size = null;
         }
@@ -46,14 +45,22 @@ class LinkSpecDocument extends LinkSpec
             $q = "SELECT filename FROM ~files WHERE id = ?";
             $filename = Pdb::query($q, [$id], 'val');
 
-            if ($size) {
+            if ($size and preg_match('/^[a-z_]+$/', $size)) {
+                $size_filename = File::getResizeFilename($filename, $size);
+
+                // Ship this off to create the size in async.
+                if (!File::exists($size_filename)) {
+                    return Sprout::absRoot() . "file/download/{$id}/{$size}";
+                }
+
+            } else if ($size) {
                 return Sprout::absRoot() . File::sizeUrl($filename, $size);
-            }
-            else {
+
+            } else {
                 return File::absUrl($filename);
             }
-        }
-        catch (RowMissingException $e) {
+
+        } catch (RowMissingException $e) {
             return Sprout::absRoot() . 'files/missing.png';
         }
     }

--- a/src/sprout/Helpers/LinkSpecDocument.php
+++ b/src/sprout/Helpers/LinkSpecDocument.php
@@ -24,17 +24,16 @@ class LinkSpecDocument extends LinkSpec
     /**
      * Get the URL for a given link.
      *
-     * @param array|int $specdata [id, size] or naked ID (backwards compat)
+     * @param int $specdata file ID
      * @return string absolute URL
      */
     public function getUrl($specdata)
     {
+        // Compat with LinkSpecImage.
         if (is_array($specdata)) {
             $id = $specdata['id'] ?? 0;
-            $size = $specdata['size'] ?? null;
         } else {
             $id = (int) $specdata;
-            $size = null;
         }
 
         if (empty($id)) {
@@ -44,21 +43,7 @@ class LinkSpecDocument extends LinkSpec
         try {
             $q = "SELECT filename FROM ~files WHERE id = ?";
             $filename = Pdb::query($q, [$id], 'val');
-
-            if ($size and preg_match('/^[a-z_]+$/', $size)) {
-                $size_filename = File::getResizeFilename($filename, $size);
-
-                // Ship this off to create the size in async.
-                if (!File::exists($size_filename)) {
-                    return Sprout::absRoot() . "file/download/{$id}/{$size}";
-                }
-
-            } else if ($size) {
-                return Sprout::absRoot() . File::sizeUrl($filename, $size);
-
-            } else {
-                return File::absUrl($filename);
-            }
+            return File::absUrl($filename);
 
         } catch (RowMissingException $e) {
             return Sprout::absRoot() . 'files/missing.png';

--- a/src/sprout/Helpers/LinkSpecImage.php
+++ b/src/sprout/Helpers/LinkSpecImage.php
@@ -1,0 +1,136 @@
+<?php
+/*
+ * Copyright (C) 2017 Karmabunny Pty Ltd.
+ *
+ * This file is a part of SproutCMS.
+ *
+ * SproutCMS is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU General Public License as published by the Free Software Foundation, either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * For more information, visit <http://getsproutcms.com>.
+ */
+
+namespace Sprout\Helpers;
+
+use karmabunny\pdb\Exceptions\RowMissingException;
+use Kohana;
+use Sprout\Helpers\FileConstants;
+use Sprout\Helpers\Form;
+
+
+/**
+ * Like LinkSpecDocument but specialised for images with resizing.
+ *
+ * @package Sprout\Helpers
+ */
+class LinkSpecImage extends LinkSpec
+{
+
+    /**
+     * Get the URL for a given link.
+     *
+     * @param array $specdata [id, size]
+     * @return string absolute URL
+     */
+    public function getUrl($specdata)
+    {
+        $id = $specdata['id'] ?? 0;
+        $size = $specdata['size'] ?? null;
+
+        if (empty($id)) {
+            return Sprout::absRoot() . 'files/missing.png';
+        }
+
+        try {
+            $q = "SELECT filename FROM ~files WHERE id = ?";
+            $filename = Pdb::query($q, [$id], 'val');
+
+            if ($size and preg_match('/^[a-z_]+$/', $size)) {
+                // Named resize.
+                $size_filename = File::getResizeFilename($filename, $size);
+
+                // Ship this off to create the size in async.
+                if (!File::exists($size_filename)) {
+                    return Sprout::absRoot() . "file/download/{$id}/{$size}";
+                }
+
+                return Sprout::absRoot() . File::sizeUrl($filename, $size);
+
+            } else if ($size) {
+                // Dynamic resize.
+                return Sprout::absRoot() . File::sizeUrl($filename, $size);
+
+            } else {
+                // No resize.
+                return File::absUrl($filename);
+            }
+
+        } catch (RowMissingException $e) {
+            return Sprout::absRoot() . 'files/missing.png';
+        }
+    }
+
+
+    /**
+    * Get any extra html attributes to use for a given link
+    * @return array
+    **/
+    public function getAttrs($specdata)
+    {
+        return array();
+    }
+
+
+    /**
+    * If there are any {@see Needs} calls that the edit form requires, they should be loaded here
+    **/
+    public function loadNeeds()
+    {
+    }
+
+
+    /**
+    * Get the HTML to use for editing a given linkspec
+    *
+    * The HTML should create a HTML field with the name $field_name
+    * If there is a spec currently being edited, the specdata will
+    * be provided in $curr_specdata
+    **/
+    public function getEditForm($field_name, $curr_specdata)
+    {
+        if (is_array($curr_specdata)) {
+            $id = $curr_specdata['id'] ?? 0;
+            $size = $curr_specdata['size'] ?? '';
+        } else {
+            $id = (int) $curr_specdata;
+            $size = '';
+        }
+
+        Form::setData([
+            $field_name => $id,
+            '_size' => $size ?? null,
+        ]);
+
+        $sizes = Kohana::config('file.image_transformations');
+        $sizes = array_keys($sizes);
+        $sizes = array_combine($sizes, array_map([Inflector::class, 'title'], $sizes));
+
+        Form::nextFieldDetails('Image', true);
+        $out = Form::fileselector($field_name, ['filter' => FileConstants::TYPE_IMAGE]);
+
+        Form::nextFieldDetails('Size', false);
+        $out .= Form::dropdown('_size', ['-dropdown-top' => 'Original'], $sizes);
+        return $out;
+    }
+
+
+    /**
+    * Validate the submission, for instances where certain constraints apply
+    **/
+    public function isValid($specdata)
+    {
+        return true;
+    }
+
+}

--- a/src/sprout/Helpers/Lnk.php
+++ b/src/sprout/Helpers/Lnk.php
@@ -70,7 +70,7 @@ class Lnk
     * @throw InvalidArgumentException If the link specification is invalid
     * @throw InvalidArgumentException If the class is not found
     * @param string $spec
-    * @return array [0] => instance, [1] => spec data
+    * @return array [0] => instance, [1] => spec data, [2] => spec label (as registered)
     **/
     private static function instance($spec)
     {

--- a/src/sprout/Helpers/Lnk.php
+++ b/src/sprout/Helpers/Lnk.php
@@ -69,13 +69,16 @@ class Lnk
     *
     * @throw InvalidArgumentException If the link specification is invalid
     * @throw InvalidArgumentException If the class is not found
-    * @param string $spec
+    * @param string|array $spec
     * @return array [0] => instance, [1] => spec data, [2] => spec label (as registered)
     **/
     private static function instance($spec)
     {
-        $spec = @json_decode($spec, true);
-        if ($spec === null) {
+        if (!is_array($spec)) {
+            $spec = @json_decode($spec, true);
+        }
+
+        if (!is_array($spec)) {
             throw new InvalidArgumentException('Invalid link specification - parse error');
         }
 
@@ -101,7 +104,7 @@ class Lnk
     /**
     * Convert a link specification into a URL.
     *
-    * @param string $spec A link specification
+    * @param string|array $spec A link specification
     * @return string Target URL
     **/
     public static function url($spec)
@@ -122,7 +125,7 @@ class Lnk
      * Helpful when you wish to avoid breaking pages when someone deletes the linked record, e.g. a blog post,
      * without updating the corresponding link(s).
      *
-     * @param string $spec A JSON link specification
+     * @param string|array $spec A JSON link specification
      * @return string|null The target URL or null if the spec is empty or if a RowMissingException
      *                     is thrown during processing.
      * @throws InvalidArgumentException If the link specification is malformed
@@ -144,7 +147,7 @@ class Lnk
     /**
     * Return an opening A tag for a link specification.
     *
-    * @param string $spec A link specification
+    * @param string|array $spec A link specification
     * @param array $attributes Additional link attributes
     *        These take precedence over any default attributes
     * @return string HTML for an opening A tag
@@ -169,7 +172,7 @@ class Lnk
     /**
     * Output the name of the type of the linkspec.
     *
-    * @param string $spec A link specification
+    * @param string|array $spec A link specification
     * @return string
     **/
     public static function typename($spec)
@@ -182,7 +185,7 @@ class Lnk
     /**
     * Check if the data supplied for a spec is valid.
     *
-    * @param string $spec A link specification
+    * @param string|array $spec A link specification
     * @return bool True if valid, false if invalid
     **/
     public static function valid($spec)

--- a/src/sprout/Helpers/Lnk.php
+++ b/src/sprout/Helpers/Lnk.php
@@ -70,9 +70,10 @@ class Lnk
     * @throw InvalidArgumentException If the link specification is invalid
     * @throw InvalidArgumentException If the class is not found
     * @param string|array $spec
+    * @param class-string<LinkSpec>|class-string<LinkSpec>[] $assert
     * @return array [0] => instance, [1] => spec data, [2] => spec label (as registered)
     **/
-    private static function instance($spec)
+    private static function instance($spec, $assert = null)
     {
         if (!is_array($spec)) {
             $spec = @json_decode($spec, true);
@@ -95,7 +96,7 @@ class Lnk
             throw new InvalidArgumentException('Link specification refers to non-registered class');
         }
 
-        $inst = new $spec['class'];
+        $inst = Sprout::instance($spec['class'], $assert);
 
         return array($inst, $spec['data'], $specs[$spec['class']]);
     }

--- a/src/sprout/Helpers/Lnk.php
+++ b/src/sprout/Helpers/Lnk.php
@@ -67,11 +67,10 @@ class Lnk
     /**
     * For a given link specification, instance it's class
     *
-    * @throw InvalidArgumentException If the link specification is invalid
-    * @throw InvalidArgumentException If the class is not found
     * @param string|array $spec
     * @param class-string<LinkSpec>|class-string<LinkSpec>[] $assert
     * @return array [0] => instance, [1] => spec data, [2] => spec label (as registered)
+    * @throws InvalidArgumentException If the link specification is malformed (invalid data, missing class)
     **/
     private static function instance($spec, $assert = null)
     {
@@ -107,6 +106,7 @@ class Lnk
     *
     * @param string|array $spec A link specification
     * @return string Target URL
+    * @throws InvalidArgumentException If the link specification is malformed (invalid data, missing class)
     **/
     public static function url($spec)
     {
@@ -129,7 +129,7 @@ class Lnk
      * @param string|array $spec A JSON link specification
      * @return string|null The target URL or null if the spec is empty or if a RowMissingException
      *                     is thrown during processing.
-     * @throws InvalidArgumentException If the link specification is malformed
+     * @throws InvalidArgumentException If the link specification is malformed (invalid data, missing class)
      */
     public static function tryUrl($spec)
     {
@@ -152,6 +152,7 @@ class Lnk
     * @param array $attributes Additional link attributes
     *        These take precedence over any default attributes
     * @return string HTML for an opening A tag
+    * @throws InvalidArgumentException If the link specification is malformed (invalid data, missing class)
     **/
     public static function atag($spec, $attributes = array()) {
         list($inst, $data) = self::instance($spec);
@@ -175,6 +176,7 @@ class Lnk
     *
     * @param string|array $spec A link specification
     * @return string
+    * @throws InvalidArgumentException If the link specification is malformed (invalid data, missing class)
     **/
     public static function typename($spec)
     {
@@ -188,6 +190,7 @@ class Lnk
     *
     * @param string|array $spec A link specification
     * @return bool True if valid, false if invalid
+    * @throws InvalidArgumentException If the link specification is malformed (invalid data, missing class)
     **/
     public static function valid($spec)
     {

--- a/src/sprout/Helpers/Lnk.php
+++ b/src/sprout/Helpers/Lnk.php
@@ -72,7 +72,23 @@ class Lnk
     * @return array [0] => instance, [1] => spec data, [2] => spec label (as registered)
     * @throws InvalidArgumentException If the link specification is malformed (invalid data, missing class)
     **/
-    private static function instance($spec, $assert = null)
+    public static function instance($spec, $assert = null)
+    {
+        $spec = self::parse($spec, true);
+        $inst = Sprout::instance($spec['class'], $assert);
+
+        return array($inst, $spec['data'], $spec['label']);
+    }
+
+
+    /**
+     * Parse a link specification.
+     *
+     * @param mixed $spec
+     * @return array [ class, data, label ]
+     * @throws InvalidArgumentException
+     */
+    public static function parse($spec)
     {
         if (!is_array($spec)) {
             $spec = @json_decode($spec, true);
@@ -82,22 +98,34 @@ class Lnk
             throw new InvalidArgumentException('Invalid link specification - parse error');
         }
 
-        if (!isset($spec['class']) or !isset($spec['data'])) {
+        $class = $spec['class'] ?? null;
+        $data = $spec['data'] ?? null;
+
+        if (!$class or $data === null) {
             throw new InvalidArgumentException('Invalid link specification - missing fields');
         }
 
-        if (!class_exists($spec['class'])) {
-            throw new InvalidArgumentException('Link specification refers to non-existant class');
-        }
-
+        $class = '\\' . ltrim($class, '\\');
         $specs = Register::getLinkspecs();
-        if (!isset($specs[$spec['class']])) {
-            throw new InvalidArgumentException('Link specification refers to non-registered class');
+
+        if (!isset($specs[$class])) {
+            $message = 'Link specification refers to non-registered class';
+
+            if (!IN_PRODUCTION) {
+                $message .= ': ' . $class;
+            }
+
+            throw new InvalidArgumentException($message);
         }
 
-        $inst = Sprout::instance($spec['class'], $assert);
+        $label = $specs[$class];
 
-        return array($inst, $spec['data'], $specs[$spec['class']]);
+        if (empty($spec['label'])) {
+            $spec['label'] = $label;
+        }
+
+        $spec['class'] = $class;
+        return $spec;
     }
 
 

--- a/src/sprout/Helpers/Register.php
+++ b/src/sprout/Helpers/Register.php
@@ -202,6 +202,7 @@ class Register
     **/
     public static function linkspec($name, $label)
     {
+        $name = '\\' . ltrim($name, '\\');
         self::$linkspecs[$name] = $label;
     }
 

--- a/src/sprout/config/routes.php
+++ b/src/sprout/config/routes.php
@@ -38,7 +38,6 @@ $config['admin_ajax/lnk_editor'] = 'AdminAjaxController/lnkEditor';
 $config['admin_ajax/tour_complete/([-_a-zA-Z0-9]+)'] = 'AdminAjaxController/setTourCompleted/$1';
 $config['admin_ajax/richtext_import/([^/]+)'] = 'AdminAjaxController/richtextImport/$1';
 $config['admin_ajax/richtext_import_iframe'] = 'AdminAjaxController/richtextImportIframe';
-$config['admin_ajax/lnk_editor'] = 'AdminAjaxController/lnkEditor';
 $config['admin_ajax/style_guide_demo_conditions'] = 'AdminAjaxController/styleGuideDemoConditions';
 
 $config['admin/?'] = 'AdminController/index';

--- a/src/sprout/media/css/admin_layout.css
+++ b/src/sprout/media/css/admin_layout.css
@@ -4313,6 +4313,12 @@ input[type=range]::-moz-focus-outer {
     background-color: red;
 }
 
+.lnk-form.LinkSpecImage {
+    display: grid;
+    grid-template-columns: 3fr 1fr;
+    gap: 10px;
+}
+
 /* ---- Autocomplete ---- */
 .ui-autocomplete {
     list-style: none;

--- a/src/sprout/sprout_load.php
+++ b/src/sprout/sprout_load.php
@@ -40,6 +40,7 @@ Register::linkspec('\\Sprout\\Helpers\\LinkSpecExternal', 'External URL');
 Register::linkspec('\\Sprout\\Helpers\\LinkSpecInternal', 'Internal URL');
 Register::linkspec('\\Sprout\\Helpers\\LinkSpecPage', 'Internal Page');
 Register::linkspec('\\Sprout\\Helpers\\LinkSpecDocument', 'Document');
+Register::linkspec('\\Sprout\\Helpers\\LinkSpecImage', 'Image');
 
 Register::rteLibrary('\\Sprout\\Helpers\\RteLibraryPages');
 Register::rteLibrary('\\Sprout\\Helpers\\RteLibraryDocuments');


### PR DESCRIPTION
Well this got out of hand.

> _It all started with a dream. A dream that made image redirects less rubbish._

Sprout will automatically add redirects for a file (and any image resizes) when it is replaced. This is a pretty neat feature but falls a little short when we want to preserve filenames for the client. At the moment, Sprout will only add an internal link to `file/download/ID` which is pretty rough (but reliable).

This PR changes that to use `LinkSpecDocument`, one that can reference a file ID directly. However, this lacks the ability to indicate resizes so this also introduces `LinkSpecImage`.

A sample form can be seen here:

![image](https://github.com/user-attachments/assets/ec24454b-fbf2-4772-a173-58890978506d)

There are some minor refactors for the LinkSpec parser and related helpers.