### PR TITLE
Feat/delete file model

### DIFF
--- a/src/sprout/Models/FileModel.php
+++ b/src/sprout/Models/FileModel.php
@@ -270,4 +270,16 @@ class FileModel extends Model
 
         return File::moveUpload($src, $this->filename);
     }
+
+
+    /**
+     * Delete the file and the record.
+     *
+     * @return bool True on success
+     */
+    public function delete(): bool
+    {
+        File::delete($this->filename);
+        return parent::delete();
+    }
 }

--- a/tests/FileModelTest.php
+++ b/tests/FileModelTest.php
@@ -1,0 +1,51 @@
+<?php
+/*
+ * Copyright (C) 2025 Karmabunny Pty Ltd.
+ *
+ * This file is a part of SproutCMS.
+ *
+ * SproutCMS is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU General Public License as published by the Free Software Foundation, either
+ */
+use PHPUnit\Framework\TestCase;
+use Sprout\Models\FileModel;
+
+
+class FileModelTest extends TestCase
+{
+    public function testDelete()
+    {
+        $file = STORAGE_PATH . 'temp/test-delete.txt';
+        file_put_contents($file, 'test delete');
+
+        $model = FileModel::fromPath([
+                'name' => 'Test delete',
+                'filename' => $file,
+            ],
+            $file);
+
+        $model->save();
+
+        $this->assertTrue($model->delete());
+        $this->assertFalse(file_exists(WEBROOT . "files/{$model->filename}"));
+    }
+
+
+    public function testMoveFile()
+    {
+        $file = STORAGE_PATH . 'temp/test-move.txt';
+        file_put_contents($file, 'test move');
+
+        $model = FileModel::fromPath([
+                'name' => 'Test move',
+                'filename' => $file,
+            ],
+            $file);
+
+        $model->save();
+
+        $this->assertTrue($model->moveFile('test-renamed.txt'));
+        $this->assertTrue(file_exists(WEBROOT . "files/test-renamed.txt"));
+        $this->assertFalse(file_exists(WEBROOT . "files/test-move.txt"));
+    }
+}


### PR DESCRIPTION
Updates `FileModel->delete()` to also delete the physical file

# Tests fail!

```
Sprout\Exceptions\FileUploadException: Failed to move uploaded file
/srv/sprout3/src/sprout/Models/FileModel.php:214
```

This is the `FileModel::fromPath` unable to move file. So something setup wrong in my tests, not a fault in the delete method, hopefully.

This PR is mostly to get the ball rolling with any fixes that maybe required, then approved.