### PR TITLE
Feat/subsite auth checks

### DIFF
--- a/src/sprout/Helpers/AI/OpenAiApi.php
+++ b/src/sprout/Helpers/AI/OpenAiApi.php
@@ -178,6 +178,12 @@ class OpenAiApi implements AiApiInterface
             'messages' => $prompt,
         ];
 
+        // If the model begins with 'o1' we need to replace 'max_tokens' with 'max_completion_tokens'
+        if (str_starts_with($data['model'], 'o')) {
+            $data['max_completion_tokens'] = $data['max_tokens'];
+            unset($data['max_tokens']);
+        }
+
         if (!empty($config['response_format'])) {
             $data['response_format'] = $config['response_format'];
         }

--- a/src/sprout/Helpers/CoreAdminAuth.php
+++ b/src/sprout/Helpers/CoreAdminAuth.php
@@ -54,7 +54,7 @@ class CoreAdminAuth extends Auth implements AdminAuthInterface
     **/
     public static function checkLogin($msg = null)
     {
-        if (! self::isLoggedIn()) {
+        if (!self::isLoggedIn() and !preg_match('!^(admin/log(in|in_action|out))$!', Router::$current_uri)) {
             $redirect = Enc::url(Url::current());
 
             if (Router::$controller == 'admin' and Router::$method == 'index') {

--- a/src/sprout/Helpers/SubsiteSelector.php
+++ b/src/sprout/Helpers/SubsiteSelector.php
@@ -94,13 +94,17 @@ class SubsiteSelector
 
             // If admin access is required to view the subsite
             if ($row['require_admin']) {
-                if (! AdminAuth::isLoggedIn()) continue;
+                if (!AdminAuth::isLoggedIn()) {
+                    AdminAuth::checkLogin();
+                }
             }
 
             // If user access is required to view the subsite
             if ($row['require_user']) {
-                if (! Register::hasFeature('users')) continue;
-                if (! UserAuth::isLoggedIn()) continue;
+                if (!Register::hasFeature('users')) continue;
+                if (!UserAuth::isLoggedIn()) {
+                    UserAuth::checkLogin();
+                }
             }
 
             $selected = $row;


### PR DESCRIPTION
Fairly simple change to stop subsites falling through to default when not logged in - it should force login

Also avoids forcing admin login when the URL is part of the login process

That open AI commit slipped in, but that's harmless