### PR TITLE
Feat/remove myisam

### DIFF
--- a/src/sprout/core/Kohana.php
+++ b/src/sprout/core/Kohana.php
@@ -879,6 +879,8 @@ final class Kohana {
         }
 
         if (!$insert) {
+            // Using auto prefixing is probably safe now, because it's a
+            // separate PDB instance there's little risk from overrides.
             $table = $pdb->config->prefix . 'exception_log';
 
             $insert_q = "INSERT INTO {$table}

--- a/src/sprout/core/Kohana.php
+++ b/src/sprout/core/Kohana.php
@@ -928,7 +928,7 @@ final class Kohana {
             $previous = $previous->getPrevious();
         }
 
-        $insert->execute([
+        $pdb->execute($insert, [
             'date' => $pdb->now(),
             'class' => get_class($exception),
             'message' => substr($exception->getMessage(), 0, 500),
@@ -941,13 +941,11 @@ final class Kohana {
             'type' => 'php',
             'ip_address' => bin2hex(inet_pton(Request::userIp())),
             'session_id' => Session::id(),
-        ]);
+        ], 'null');
 
         $log_id = $pdb->getLastInsertId();
-        $insert->closeCursor();
 
-        $delete->execute([$pdb->now()]);
-        $delete->closeCursor();
+        $pdb->execute($delete, [$pdb->now()], 'null');
 
         return (int) $log_id;
     }

--- a/src/sprout/db_struct.xml
+++ b/src/sprout/db_struct.xml
@@ -911,7 +911,7 @@
 
     <!-- Only used if Kohana sessions are using the 'database' driver -->
     <!-- See sprout/kohana_system/config/session.php -->
-    <table name="sessions" engine="MyISAM">
+    <table name="sessions" engine="InnoDB">
         <column name="id" type="BIGINT UNSIGNED" allownull="0" autoinc="1" />
         <column name="session_id" type="VARCHAR(40)" allownull="0" />
         <column name="last_activity" type="INT" allownull="0" />
@@ -1086,7 +1086,7 @@
         </index>
     </table>
 
-    <table name="exception_log" engine="MyISAM">
+    <table name="exception_log" engine="InnoDB">
         <column name="id" type="INT UNSIGNED" allownull="0" autoinc="1" />
         <column name="date_generated" type="DATETIME" allownull="0" />
         <column name="class_name" type="VARCHAR(200)" allownull="0" />

--- a/tests/ExceptionLogTest.php
+++ b/tests/ExceptionLogTest.php
@@ -1,0 +1,52 @@
+<?php
+/*
+ * Copyright (C) 2017 Karmabunny Pty Ltd.
+ *
+ * This file is a part of SproutCMS.
+ *
+ * SproutCMS is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU General Public License as published by the Free Software Foundation, either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * For more information, visit <http://getsproutcms.com>.
+ */
+
+use PHPUnit\Framework\TestCase;
+use Sprout\Helpers\Pdb;
+
+
+class ExceptionLogTest extends TestCase
+{
+
+    public function testNoRollback()
+    {
+        Pdb::transact();
+
+        $id = Pdb::insert('login_attempts', [
+            'date_added' => Pdb::now(),
+            'date_modified' => Pdb::now(),
+            'username' => 'test',
+            'ip' => bin2hex(inet_pton('127.0.0.1')),
+            'success' => 1,
+            'active' => 1,
+        ]);
+
+        $row = Pdb::find('login_attempts')->where(['id' => $id])->one(false);
+        $this->assertNotNull($row);
+
+        $exception = new Exception('test: ' . uniqid());
+        $id = Kohana::logException($exception);
+        $this->assertNotEmpty($id);
+
+        Pdb::rollback();
+
+        // This proves the rollback worked.
+        $row = Pdb::find('login_attempts')->where(['id' => $id])->one(false);
+        $this->assertNull($row);
+
+        // However, the exception was not included in the transaction.
+        $row = Pdb::find('exception_log')->where(['id' => $id])->one(false);
+        $this->assertNotNull($row);
+        $this->assertEquals($exception->getMessage(), $row['message']);
+    }
+}

--- a/tests/ExceptionLogTest.php
+++ b/tests/ExceptionLogTest.php
@@ -18,7 +18,19 @@ use Sprout\Helpers\Pdb;
 class ExceptionLogTest extends TestCase
 {
 
-    public function testNoRollback()
+
+    public function dataRollbacks()
+    {
+        return [
+            ['test: ' . uniqid()],
+            ['test: ' . uniqid()],
+            ['test: ' . uniqid()],
+        ];
+    }
+
+
+    /** @dataProvider dataRollbacks */
+    public function testNoRollback($message)
     {
         Pdb::transact();
 
@@ -34,7 +46,7 @@ class ExceptionLogTest extends TestCase
         $row = Pdb::find('login_attempts')->where(['id' => $id])->one(false);
         $this->assertNotNull($row);
 
-        $exception = new Exception('test: ' . uniqid());
+        $exception = new Exception($message);
         $id = Kohana::logException($exception);
         $this->assertNotEmpty($id);
 


### PR DESCRIPTION
Real easy this one.

Basically I did this to confirm the correct behaviour:

```php
Pdb::transact();
Kohana::logException(new Exception('test'));
Pdb::rollback();
```

The exception is still logged despite the transaction being cancelled.

~Perhaps we should put that into a test suite.~ Test included. Which also uncovered a bug, so remember that kids - always write a test.
