### PR TITLE
Feat/countries phones

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,7 @@
         "cebe/markdown": "^1.2",
         "davechild/textstatistics": "^1.0",
         "ezyang/htmlpurifier": "^4.17",
+        "giggsey/libphonenumber-for-php": "^8.13",
         "guzzlehttp/guzzle": "^7.9",
         "karmabunny/kb": "^3.58",
         "karmabunny/pdb": "^1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e0f3f729f8c24b7b8bff38ead8667187",
+    "content-hash": "d1f35435672a5e3a6afe5982e06fb11d",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -444,6 +444,139 @@
                 "source": "https://github.com/ezyang/htmlpurifier/tree/v4.18.0"
             },
             "time": "2024-11-01T03:51:45+00:00"
+        },
+        {
+            "name": "giggsey/libphonenumber-for-php",
+            "version": "8.13.55",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/giggsey/libphonenumber-for-php.git",
+                "reference": "6e28b3d53cf96d7f41c83d9b80b6021ecbd00537"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/giggsey/libphonenumber-for-php/zipball/6e28b3d53cf96d7f41c83d9b80b6021ecbd00537",
+                "reference": "6e28b3d53cf96d7f41c83d9b80b6021ecbd00537",
+                "shasum": ""
+            },
+            "require": {
+                "giggsey/locale": "^2.0",
+                "php": "^7.4|^8.0",
+                "symfony/polyfill-mbstring": "^1.17"
+            },
+            "replace": {
+                "giggsey/libphonenumber-for-php-lite": "self.version"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.64",
+                "pear/pear-core-minimal": "^1.10",
+                "pear/pear_exception": "^1.0",
+                "pear/versioncontrol_git": "^0.7",
+                "phing/phing": "^3.0",
+                "php-coveralls/php-coveralls": "^2.0",
+                "phpunit/phpunit": "^9.6",
+                "symfony/console": "^v5.2",
+                "symfony/var-exporter": "^5.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "libphonenumber\\": "src/"
+                },
+                "exclude-from-classmap": [
+                    "/src/data/",
+                    "/src/carrier/data/",
+                    "/src/geocoding/data/",
+                    "/src/timezone/data/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Joshua Gigg",
+                    "email": "giggsey@gmail.com",
+                    "homepage": "https://giggsey.com/"
+                }
+            ],
+            "description": "PHP Port of Google's libphonenumber",
+            "homepage": "https://github.com/giggsey/libphonenumber-for-php",
+            "keywords": [
+                "geocoding",
+                "geolocation",
+                "libphonenumber",
+                "mobile",
+                "phonenumber",
+                "validation"
+            ],
+            "support": {
+                "issues": "https://github.com/giggsey/libphonenumber-for-php/issues",
+                "source": "https://github.com/giggsey/libphonenumber-for-php"
+            },
+            "time": "2025-02-14T08:14:08+00:00"
+        },
+        {
+            "name": "giggsey/locale",
+            "version": "2.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/giggsey/Locale.git",
+                "reference": "1cd8b3ad2d43e04f4c2c6a240495af44780f809b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/giggsey/Locale/zipball/1cd8b3ad2d43e04f4c2c6a240495af44780f809b",
+                "reference": "1cd8b3ad2d43e04f4c2c6a240495af44780f809b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "ext-json": "*",
+                "friendsofphp/php-cs-fixer": "^3.66",
+                "pear/pear-core-minimal": "^1.10",
+                "pear/pear_exception": "^1.0",
+                "pear/versioncontrol_git": "^0.5",
+                "phing/phing": "^2.17.4",
+                "php-coveralls/php-coveralls": "^2.7",
+                "phpunit/phpunit": "^10.5.45",
+                "symfony/console": "^6.4",
+                "symfony/filesystem": "6.4",
+                "symfony/finder": "^6.4",
+                "symfony/process": "^6.4",
+                "symfony/var-exporter": "^6.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Giggsey\\Locale\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Joshua Gigg",
+                    "email": "giggsey@gmail.com",
+                    "homepage": "https://giggsey.com/"
+                }
+            ],
+            "description": "Locale functions required by libphonenumber-for-php",
+            "support": {
+                "issues": "https://github.com/giggsey/Locale/issues",
+                "source": "https://github.com/giggsey/Locale/tree/2.8.0"
+            },
+            "time": "2025-03-20T14:25:27+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -7136,5 +7269,5 @@
     "platform-overrides": {
         "php": "8.1"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/src/sprout/Helpers/I18n.php
+++ b/src/sprout/Helpers/I18n.php
@@ -38,7 +38,7 @@ class I18n
     public static function init()
     {
         $l = Kohana::config('sprout.locale');
-        if ($l == '') $l = 'AUS';
+        if ($l == '') $l = Kohana::config('config.default_country_code');
         self::$locale = LocaleInfo::get($l);
     }
 

--- a/src/sprout/Helpers/Locales/LocaleInfo.php
+++ b/src/sprout/Helpers/Locales/LocaleInfo.php
@@ -38,6 +38,8 @@ class LocaleInfo
 
     protected $postcode_name = 'Postcode';
 
+    protected $phone_code = '';
+
     protected $decimal_seperator = '.';
     protected $group_seperator = ',';
 
@@ -102,6 +104,7 @@ class LocaleInfo
             'currency_symbol' => $this->currency_symbol,
             'currency_decimal' => $this->currency_decimal,
             'currency_iso' => $this->currency_iso,
+            'phone_code' => $this->phone_code,
         ];
     }
 
@@ -425,4 +428,16 @@ class LocaleInfo
     {
         return $this->currency_iso;
     }
+
+
+    /**
+     * Return phone code, eg '213'
+     *
+     * @return string eg '213'
+     */
+    public function getPhoneCode()
+    {
+        return $this->phone_code;
+    }
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfo.php
+++ b/src/sprout/Helpers/Locales/LocaleInfo.php
@@ -61,7 +61,7 @@ class LocaleInfo
     {
         if (! self::$auto) {
             $l = Kohana::config('sprout.locale');
-            if ($l == '') $l = 'AUS';
+            if ($l == '') $l = Kohana::config('config.default_country_code');
             self::$auto = self::get($l);
         }
 

--- a/src/sprout/Helpers/Locales/LocaleInfo.php
+++ b/src/sprout/Helpers/Locales/LocaleInfo.php
@@ -160,7 +160,7 @@ class LocaleInfo
      *
      * @param string $val Values stored by the {@see LocaleInfo::outputAddressFields} dropdown field
      * @return string Full name of state, e.g. 'South Australia'
-     * @return null If the country does not have states (e.g. Vatican City)
+     * @return string|null If the country does not have states (e.g. Vatican City)
      */
     public function getStateName($val)
     {
@@ -332,7 +332,7 @@ class LocaleInfo
     /**
     * Formats numbers, like the interal {@see number_format} function
     *
-    * @param int|float The number to format
+    * @param int|float $number The number to format
     * @param int $precision The number of decimal places to render
     * @return string
     **/
@@ -345,7 +345,7 @@ class LocaleInfo
     /**
     * Formats currency values, similar to the interal {@see number_format} function
     *
-    * @param int|float The number to format
+    * @param int|float $number The number to format
     * @param int $precision The number of decimal places to render; if NULL then it's locale-dependent
     * @return string
     **/

--- a/src/sprout/Helpers/Locales/LocaleInfoAFG.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoAFG.php
@@ -58,4 +58,6 @@ class LocaleInfoAFG extends LocaleInfo
 
 
     protected $currency_iso = 'AFN';
+    protected $phone_code = '93';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoAGO.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoAGO.php
@@ -42,4 +42,6 @@ class LocaleInfoAGO extends LocaleInfo
 
 
     protected $currency_iso = 'AOA';
+    protected $phone_code = '244';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoALB.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoALB.php
@@ -36,4 +36,6 @@ class LocaleInfoALB extends LocaleInfo
 
 
     protected $currency_iso = 'ALL';
+    protected $phone_code = '355';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoAND.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoAND.php
@@ -31,4 +31,6 @@ class LocaleInfoAND extends LocaleInfo
 
 
     protected $currency_iso = 'EUR';
+    protected $phone_code = '376';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoARE.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoARE.php
@@ -31,4 +31,6 @@ class LocaleInfoARE extends LocaleInfo
 
 
     protected $currency_iso = 'AED';
+    protected $phone_code = '971';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoARG.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoARG.php
@@ -48,4 +48,6 @@ class LocaleInfoARG extends LocaleInfo
 
 
     protected $currency_iso = 'ARS';
+    protected $phone_code = '54';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoARM.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoARM.php
@@ -35,4 +35,6 @@ class LocaleInfoARM extends LocaleInfo
 
 
     protected $currency_iso = 'AMD';
+    protected $phone_code = '374';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoATA.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoATA.php
@@ -104,4 +104,8 @@ class LocaleInfoATA extends LocaleInfo
     protected $line1 = 'Room';
 
     protected $postcode_name = null;
+
+    protected $currency_iso = 'EUR';
+    protected $phone_code = '672';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoATG.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoATG.php
@@ -32,4 +32,6 @@ class LocaleInfoATG extends LocaleInfo
 
 
     protected $currency_iso = 'XCD';
+    protected $phone_code = '1268';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoAUS.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoAUS.php
@@ -54,4 +54,6 @@ class LocaleInfoAUS extends LocaleInfo
 
 
     protected $currency_iso = 'AUD';
+    protected $phone_code = '61';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoAUT.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoAUT.php
@@ -33,4 +33,6 @@ class LocaleInfoAUT extends LocaleInfo
 
 
     protected $currency_iso = 'EUR';
+    protected $phone_code = '43';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoAZE.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoAZE.php
@@ -102,4 +102,6 @@ class LocaleInfoAZE extends LocaleInfo
 
 
     protected $currency_iso = 'AZN';
+    protected $phone_code = '994';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoBDI.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoBDI.php
@@ -42,4 +42,6 @@ class LocaleInfoBDI extends LocaleInfo
 
 
     protected $currency_iso = 'BIF';
+    protected $phone_code = '257';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoBEL.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoBEL.php
@@ -35,4 +35,6 @@ class LocaleInfoBEL extends LocaleInfo
 
 
     protected $currency_iso = 'EUR';
+    protected $phone_code = '32';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoBEN.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoBEN.php
@@ -36,4 +36,6 @@ class LocaleInfoBEN extends LocaleInfo
 
 
     protected $currency_iso = 'XOF';
+    protected $phone_code = '229';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoBES.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoBES.php
@@ -26,5 +26,7 @@ class LocaleInfoBES extends LocaleInfo
     ];
 
 
-    protected $currency_iso = 'XCD';
+    protected $currency_iso = 'USD';
+    protected $phone_code = '599';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoBFA.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoBFA.php
@@ -69,4 +69,6 @@ class LocaleInfoBFA extends LocaleInfo
 
 
     protected $currency_iso = 'XOF';
+    protected $phone_code = '226';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoBGD.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoBGD.php
@@ -88,4 +88,6 @@ class LocaleInfoBGD extends LocaleInfo
 
 
     protected $currency_iso = 'BDT';
+    protected $phone_code = '880';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoBGR.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoBGR.php
@@ -52,4 +52,6 @@ class LocaleInfoBGR extends LocaleInfo
 
 
     protected $currency_iso = 'BGN';
+    protected $phone_code = '359';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoBHR.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoBHR.php
@@ -28,4 +28,6 @@ class LocaleInfoBHR extends LocaleInfo
 
 
     protected $currency_iso = 'BHD';
+    protected $phone_code = '973';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoBHS.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoBHS.php
@@ -55,4 +55,6 @@ class LocaleInfoBHS extends LocaleInfo
 
 
     protected $currency_iso = 'BSD';
+    protected $phone_code = '1242';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoBIH.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoBIH.php
@@ -27,4 +27,6 @@ class LocaleInfoBIH extends LocaleInfo
 
 
     protected $currency_iso = 'BAM';
+    protected $phone_code = '387';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoBLR.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoBLR.php
@@ -31,4 +31,6 @@ class LocaleInfoBLR extends LocaleInfo
 
 
     protected $currency_iso = 'BYN';
+    protected $phone_code = '375';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoBLZ.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoBLZ.php
@@ -30,4 +30,6 @@ class LocaleInfoBLZ extends LocaleInfo
 
 
     protected $currency_iso = 'BZD';
+    protected $phone_code = '501';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoBOL.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoBOL.php
@@ -33,4 +33,6 @@ class LocaleInfoBOL extends LocaleInfo
 
 
     protected $currency_iso = 'BOB';
+    protected $phone_code = '591';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoBRA.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoBRA.php
@@ -51,4 +51,6 @@ class LocaleInfoBRA extends LocaleInfo
 
 
     protected $currency_iso = 'BRL';
+    protected $phone_code = '55';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoBRB.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoBRB.php
@@ -35,4 +35,6 @@ class LocaleInfoBRB extends LocaleInfo
 
 
     protected $currency_iso = 'BBD';
+    protected $phone_code = '1246';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoBRN.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoBRN.php
@@ -28,4 +28,6 @@ class LocaleInfoBRN extends LocaleInfo
 
 
     protected $currency_iso = 'BND';
+    protected $phone_code = '673';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoBTN.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoBTN.php
@@ -44,4 +44,6 @@ class LocaleInfoBTN extends LocaleInfo
 
 
     protected $currency_iso = 'BTN';
+    protected $phone_code = '975';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoBWA.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoBWA.php
@@ -40,4 +40,6 @@ class LocaleInfoBWA extends LocaleInfo
 
 
     protected $currency_iso = 'BWP';
+    protected $phone_code = '267';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoCAF.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoCAF.php
@@ -41,4 +41,6 @@ class LocaleInfoCAF extends LocaleInfo
 
 
     protected $currency_iso = 'XAF';
+    protected $phone_code = '236';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoCAN.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoCAN.php
@@ -89,4 +89,6 @@ class LocaleInfoCAN extends LocaleInfo
 
 
     protected $currency_iso = 'CAD';
+    protected $phone_code = '1';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoCHE.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoCHE.php
@@ -50,4 +50,6 @@ class LocaleInfoCHE extends LocaleInfo
 
 
     protected $currency_iso = 'CHF';
+    protected $phone_code = '41';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoCHL.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoCHL.php
@@ -39,4 +39,6 @@ class LocaleInfoCHL extends LocaleInfo
 
 
     protected $currency_iso = 'CLP';
+    protected $phone_code = '56';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoCHN.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoCHN.php
@@ -90,4 +90,6 @@ class LocaleInfoCHN extends LocaleInfo
 
 
     protected $currency_iso = 'CNY';
+    protected $phone_code = '86';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoCIV.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoCIV.php
@@ -38,4 +38,6 @@ class LocaleInfoCIV extends LocaleInfo
 
 
     protected $currency_iso = 'XOF';
+    protected $phone_code = '225';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoCMR.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoCMR.php
@@ -34,4 +34,6 @@ class LocaleInfoCMR extends LocaleInfo
 
 
     protected $currency_iso = 'XAF';
+    protected $phone_code = '237';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoCOD.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoCOD.php
@@ -35,4 +35,6 @@ class LocaleInfoCOD extends LocaleInfo
 
 
     protected $currency_iso = 'CDF';
+    protected $phone_code = '243';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoCOG.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoCOG.php
@@ -36,4 +36,6 @@ class LocaleInfoCOG extends LocaleInfo
 
 
     protected $currency_iso = 'XAF';
+    protected $phone_code = '242';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoCOL.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoCOL.php
@@ -57,4 +57,6 @@ class LocaleInfoCOL extends LocaleInfo
 
 
     protected $currency_iso = 'COP';
+    protected $phone_code = '57';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoCOM.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoCOM.php
@@ -27,4 +27,6 @@ class LocaleInfoCOM extends LocaleInfo
 
 
     protected $currency_iso = 'KMF';
+    protected $phone_code = '269';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoCPV.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoCPV.php
@@ -46,4 +46,6 @@ class LocaleInfoCPV extends LocaleInfo
 
 
     protected $currency_iso = 'CVE';
+    protected $phone_code = '238';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoCRI.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoCRI.php
@@ -31,4 +31,6 @@ class LocaleInfoCRI extends LocaleInfo
 
 
     protected $currency_iso = 'CRC';
+    protected $phone_code = '506';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoCUB.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoCUB.php
@@ -41,4 +41,6 @@ class LocaleInfoCUB extends LocaleInfo
 
 
     protected $currency_iso = 'CUP';
+    protected $phone_code = '53';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoCYP.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoCYP.php
@@ -30,4 +30,6 @@ class LocaleInfoCYP extends LocaleInfo
 
 
     protected $currency_iso = 'EUR';
+    protected $phone_code = '357';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoCZE.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoCZE.php
@@ -38,4 +38,6 @@ class LocaleInfoCZE extends LocaleInfo
 
 
     protected $currency_iso = 'CZK';
+    protected $phone_code = '420';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoDEU.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoDEU.php
@@ -40,4 +40,6 @@ class LocaleInfoDEU extends LocaleInfo
 
 
     protected $currency_iso = 'EUR';
+    protected $phone_code = '49';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoDJI.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoDJI.php
@@ -30,4 +30,6 @@ class LocaleInfoDJI extends LocaleInfo
 
 
     protected $currency_iso = 'DJF';
+    protected $phone_code = '253';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoDMA.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoDMA.php
@@ -34,4 +34,6 @@ class LocaleInfoDMA extends LocaleInfo
 
 
     protected $currency_iso = 'XCD';
+    protected $phone_code = '1767';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoDNK.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoDNK.php
@@ -29,4 +29,6 @@ class LocaleInfoDNK extends LocaleInfo
 
 
     protected $currency_iso = 'DKK';
+    protected $phone_code = '45';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoDOM.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoDOM.php
@@ -66,4 +66,6 @@ class LocaleInfoDOM extends LocaleInfo
 
 
     protected $currency_iso = 'DOP';
+    protected $phone_code = '1809';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoDZA.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoDZA.php
@@ -72,4 +72,6 @@ class LocaleInfoDZA extends LocaleInfo
 
 
     protected $currency_iso = 'DZD';
+    protected $phone_code = '213';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoECU.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoECU.php
@@ -48,4 +48,6 @@ class LocaleInfoECU extends LocaleInfo
 
 
     protected $currency_iso = 'USD';
+    protected $phone_code = '593';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoEGY.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoEGY.php
@@ -51,4 +51,6 @@ class LocaleInfoEGY extends LocaleInfo
 
 
     protected $currency_iso = 'EGP';
+    protected $phone_code = '20';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoERI.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoERI.php
@@ -30,4 +30,6 @@ class LocaleInfoERI extends LocaleInfo
 
 
     protected $currency_iso = 'ERN';
+    protected $phone_code = '291';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoESP.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoESP.php
@@ -76,4 +76,6 @@ class LocaleInfoESP extends LocaleInfo
 
 
     protected $currency_iso = 'EUR';
+    protected $phone_code = '34';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoEST.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoEST.php
@@ -39,4 +39,6 @@ class LocaleInfoEST extends LocaleInfo
 
 
     protected $currency_iso = 'EUR';
+    protected $phone_code = '372';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoETH.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoETH.php
@@ -35,4 +35,6 @@ class LocaleInfoETH extends LocaleInfo
 
 
     protected $currency_iso = 'ETB';
+    protected $phone_code = '251';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoFIN.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoFIN.php
@@ -43,4 +43,6 @@ class LocaleInfoFIN extends LocaleInfo
 
 
     protected $currency_iso = 'EUR';
+    protected $phone_code = '358';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoFJI.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoFJI.php
@@ -43,4 +43,6 @@ class LocaleInfoFJI extends LocaleInfo
 
 
     protected $currency_iso = 'FJD';
+    protected $phone_code = '679';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoFRA.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoFRA.php
@@ -120,4 +120,6 @@ class LocaleInfoFRA extends LocaleInfo
 
 
     protected $currency_iso = 'EUR';
+    protected $phone_code = '33';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoFSM.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoFSM.php
@@ -28,4 +28,6 @@ class LocaleInfoFSM extends LocaleInfo
 
 
     protected $currency_iso = 'USD';
+    protected $phone_code = '691';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoGAB.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoGAB.php
@@ -33,4 +33,6 @@ class LocaleInfoGAB extends LocaleInfo
 
 
     protected $currency_iso = 'XAF';
+    protected $phone_code = '241';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoGBR.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoGBR.php
@@ -124,6 +124,8 @@ class LocaleInfoGBR extends LocaleInfo
     protected $currency_symbol = '£';
     protected $currency_name = 'Pound';
 
+    protected $currency_iso = 'GBP';
+    protected $phone_code = '44';
 
     /**
      * Validate a UK postcode
@@ -182,6 +184,4 @@ class LocaleInfoGBR extends LocaleInfo
         $valid->check('postcode', 'Validity::length', 6, 8);
     }
 
-
-    protected $currency_iso = 'GBP';
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoGEO.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoGEO.php
@@ -36,4 +36,6 @@ class LocaleInfoGEO extends LocaleInfo
 
 
     protected $currency_iso = 'GEL';
+    protected $phone_code = '995';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoGHA.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoGHA.php
@@ -34,4 +34,6 @@ class LocaleInfoGHA extends LocaleInfo
 
 
     protected $currency_iso = 'GHS';
+    protected $phone_code = '233';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoGIN.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoGIN.php
@@ -57,4 +57,6 @@ class LocaleInfoGIN extends LocaleInfo
 
 
     protected $currency_iso = 'GNF';
+    protected $phone_code = '224';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoGMB.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoGMB.php
@@ -30,4 +30,6 @@ class LocaleInfoGMB extends LocaleInfo
 
 
     protected $currency_iso = 'GMD';
+    protected $phone_code = '220';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoGNB.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoGNB.php
@@ -32,4 +32,6 @@ class LocaleInfoGNB extends LocaleInfo
     ];
 
     protected $currency_iso = 'XOF';
+    protected $phone_code = '245';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoGNQ.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoGNQ.php
@@ -30,4 +30,6 @@ class LocaleInfoGNQ extends LocaleInfo
     ];
 
     protected $currency_iso = 'XAF';
+    protected $phone_code = '240';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoGRC.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoGRC.php
@@ -75,4 +75,6 @@ class LocaleInfoGRC extends LocaleInfo
     ];
 
     protected $currency_iso = 'EUR';
+    protected $phone_code = '30';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoGRD.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoGRD.php
@@ -30,4 +30,6 @@ class LocaleInfoGRD extends LocaleInfo
     ];
 
     protected $currency_iso = 'XCD';
+    protected $phone_code = '1473';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoGRL.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoGRL.php
@@ -27,4 +27,6 @@ class LocaleInfoGRL extends LocaleInfo
     ];
 
     protected $currency_iso = 'DKK';
+    protected $phone_code = '299';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoGTM.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoGTM.php
@@ -45,4 +45,6 @@ class LocaleInfoGTM extends LocaleInfo
     ];
 
     protected $currency_iso = 'GTQ';
+    protected $phone_code = '502';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoGUY.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoGUY.php
@@ -33,4 +33,6 @@ class LocaleInfoGUY extends LocaleInfo
     ];
 
     protected $currency_iso = 'GYD';
+    protected $phone_code = '592';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoHND.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoHND.php
@@ -41,4 +41,6 @@ class LocaleInfoHND extends LocaleInfo
     ];
 
     protected $currency_iso = 'HNL';
+    protected $phone_code = '504';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoHRV.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoHRV.php
@@ -44,4 +44,6 @@ class LocaleInfoHRV extends LocaleInfo
     ];
 
     protected $currency_iso = 'HRK';
+    protected $phone_code = '385';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoHTI.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoHTI.php
@@ -33,4 +33,6 @@ class LocaleInfoHTI extends LocaleInfo
     ];
 
     protected $currency_iso = 'HTG';
+    protected $phone_code = '509';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoHUN.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoHUN.php
@@ -66,4 +66,6 @@ class LocaleInfoHUN extends LocaleInfo
     ];
 
     protected $currency_iso = 'HUF';
+    protected $phone_code = '36';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoIDN.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoIDN.php
@@ -57,4 +57,6 @@ class LocaleInfoIDN extends LocaleInfo
     ];
 
     protected $currency_iso = 'IDR';
+    protected $phone_code = '62';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoIND.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoIND.php
@@ -110,4 +110,6 @@ class LocaleInfoIND extends LocaleInfo
 
 
     protected $currency_iso = 'INR';
+    protected $phone_code = '91';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoIRL.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoIRL.php
@@ -49,4 +49,6 @@ class LocaleInfoIRL extends LocaleInfo
     ];
 
     protected $currency_iso = 'EUR';
+    protected $phone_code = '353';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoIRN.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoIRN.php
@@ -54,4 +54,6 @@ class LocaleInfoIRN extends LocaleInfo
     ];
 
     protected $currency_iso = 'IRR';
+    protected $phone_code = '98';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoIRQ.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoIRQ.php
@@ -41,4 +41,6 @@ class LocaleInfoIRQ extends LocaleInfo
     ];
 
     protected $currency_iso = 'IQD';
+    protected $phone_code = '964';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoISL.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoISL.php
@@ -31,4 +31,6 @@ class LocaleInfoISL extends LocaleInfo
     ];
 
     protected $currency_iso = 'ISK';
+    protected $phone_code = '354';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoISR.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoISR.php
@@ -29,4 +29,6 @@ class LocaleInfoISR extends LocaleInfo
     ];
 
     protected $currency_iso = 'ILS';
+    protected $phone_code = '972';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoITA.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoITA.php
@@ -133,4 +133,6 @@ class LocaleInfoITA extends LocaleInfo
     ];
 
     protected $currency_iso = 'EUR';
+    protected $phone_code = '39';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoJAM.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoJAM.php
@@ -37,4 +37,6 @@ class LocaleInfoJAM extends LocaleInfo
     ];
 
     protected $currency_iso = 'JMD';
+    protected $phone_code = '1876';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoJOR.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoJOR.php
@@ -35,4 +35,6 @@ class LocaleInfoJOR extends LocaleInfo
     ];
 
     protected $currency_iso = 'JOD';
+    protected $phone_code = '962';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoJPN.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoJPN.php
@@ -90,4 +90,6 @@ class LocaleInfoJPN extends LocaleInfo
     protected $currency_decimal = 0;
     protected $currency_name = 'Yen';
     protected $currency_iso = 'JPY';
+    protected $phone_code = '81';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoKAZ.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoKAZ.php
@@ -39,4 +39,6 @@ class LocaleInfoKAZ extends LocaleInfo
     ];
 
     protected $currency_iso = 'KZT';
+    protected $phone_code = '7';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoKEN.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoKEN.php
@@ -70,4 +70,6 @@ class LocaleInfoKEN extends LocaleInfo
     ];
 
     protected $currency_iso = 'KES';
+    protected $phone_code = '254';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoKGZ.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoKGZ.php
@@ -32,4 +32,6 @@ class LocaleInfoKGZ extends LocaleInfo
     ];
 
     protected $currency_iso = 'KGS';
+    protected $phone_code = '996';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoKHM.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoKHM.php
@@ -48,4 +48,6 @@ class LocaleInfoKHM extends LocaleInfo
     ];
 
     protected $currency_iso = 'KHR';
+    protected $phone_code = '855';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoKIR.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoKIR.php
@@ -26,4 +26,6 @@ class LocaleInfoKIR extends LocaleInfo
     ];
 
     protected $currency_iso = 'KID';
+    protected $phone_code = '686';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoKNA.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoKNA.php
@@ -37,4 +37,6 @@ class LocaleInfoKNA extends LocaleInfo
     ];
 
     protected $currency_iso = 'XCD';
+    protected $phone_code = '1869';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoKOR.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoKOR.php
@@ -40,4 +40,6 @@ class LocaleInfoKOR extends LocaleInfo
     ];
 
     protected $currency_iso = 'KRW';
+    protected $phone_code = '82';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoKWT.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoKWT.php
@@ -29,4 +29,6 @@ class LocaleInfoKWT extends LocaleInfo
     ];
 
     protected $currency_iso = 'KWD';
+    protected $phone_code = '965';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoLAO.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoLAO.php
@@ -41,4 +41,6 @@ class LocaleInfoLAO extends LocaleInfo
     ];
 
     protected $currency_iso = 'LAK';
+    protected $phone_code = '856';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoLBN.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoLBN.php
@@ -31,4 +31,6 @@ class LocaleInfoLBN extends LocaleInfo
     ];
 
     protected $currency_iso = 'LBP';
+    protected $phone_code = '961';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoLBR.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoLBR.php
@@ -38,4 +38,6 @@ class LocaleInfoLBR extends LocaleInfo
     ];
 
     protected $currency_iso = 'LRD';
+    protected $phone_code = '231';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoLBY.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoLBY.php
@@ -44,5 +44,7 @@ class LocaleInfoLBY extends LocaleInfo
         'ZA' => 'Az Zāwiyah',
     ];
 
-    protected $currency_iso = 'Libya';
+    protected $currency_iso = 'LYD';
+    protected $phone_code = '218';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoLCA.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoLCA.php
@@ -33,4 +33,6 @@ class LocaleInfoLCA extends LocaleInfo
     ];
 
     protected $currency_iso = 'XCD';
+    protected $phone_code = '1758';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoLIE.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoLIE.php
@@ -34,4 +34,6 @@ class LocaleInfoLIE extends LocaleInfo
     ];
 
     protected $currency_iso = 'CHF';
+    protected $phone_code = '423';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoLKA.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoLKA.php
@@ -57,4 +57,6 @@ class LocaleInfoLKA extends LocaleInfo
     ];
 
     protected $currency_iso = 'LKR';
+    protected $phone_code = '94';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoLSO.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoLSO.php
@@ -33,4 +33,6 @@ class LocaleInfoLSO extends LocaleInfo
     ];
 
     protected $currency_iso = 'LSL';
+    protected $phone_code = '266';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoLTU.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoLTU.php
@@ -93,4 +93,6 @@ class LocaleInfoLTU extends LocaleInfo
     ];
 
     protected $currency_iso = 'EUR';
+    protected $phone_code = '370';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoLUX.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoLUX.php
@@ -35,4 +35,6 @@ class LocaleInfoLUX extends LocaleInfo
     ];
 
     protected $currency_iso = 'EUR';
+    protected $phone_code = '352';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoLVA.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoLVA.php
@@ -142,4 +142,6 @@ class LocaleInfoLVA extends LocaleInfo
     ];
 
     protected $currency_iso = 'EUR';
+    protected $phone_code = '371';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoMAR.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoMAR.php
@@ -102,4 +102,6 @@ class LocaleInfoMAR extends LocaleInfo
     ];
 
     protected $currency_iso = 'MAD';
+    protected $phone_code = '212';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoMCO.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoMCO.php
@@ -40,4 +40,6 @@ class LocaleInfoMCO extends LocaleInfo
     ];
 
     protected $currency_iso = 'EUR';
+    protected $phone_code = '377';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoMDA.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoMDA.php
@@ -60,4 +60,6 @@ class LocaleInfoMDA extends LocaleInfo
     ];
 
     protected $currency_iso = 'MDL';
+    protected $phone_code = '373';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoMDG.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoMDG.php
@@ -29,4 +29,6 @@ class LocaleInfoMDG extends LocaleInfo
     ];
 
     protected $currency_iso = 'MGA';
+    protected $phone_code = '261';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoMDV.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoMDV.php
@@ -51,4 +51,6 @@ class LocaleInfoMDV extends LocaleInfo
     ];
 
     protected $currency_iso = 'MVR';
+    protected $phone_code = '960';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoMEX.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoMEX.php
@@ -55,4 +55,6 @@ class LocaleInfoMEX extends LocaleInfo
     ];
 
     protected $currency_iso = 'MXN';
+    protected $phone_code = '52';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoMHL.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoMHL.php
@@ -49,4 +49,6 @@ class LocaleInfoMHL extends LocaleInfo
     ];
 
     protected $currency_iso = 'USD';
+    protected $phone_code = '692';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoMKD.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoMKD.php
@@ -94,4 +94,6 @@ class LocaleInfoMKD extends LocaleInfo
     ];
 
     protected $currency_iso = 'MKD';
+    protected $phone_code = '389';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoMLI.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoMLI.php
@@ -32,4 +32,6 @@ class LocaleInfoMLI extends LocaleInfo
     ];
 
     protected $currency_iso = 'XOF';
+    protected $phone_code = '223';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoMLT.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoMLT.php
@@ -91,4 +91,6 @@ class LocaleInfoMLT extends LocaleInfo
     ];
 
     protected $currency_iso = 'EUR';
+    protected $phone_code = '356';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoMMR.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoMMR.php
@@ -38,4 +38,6 @@ class LocaleInfoMMR extends LocaleInfo
     ];
 
     protected $currency_iso = 'MMK';
+    protected $phone_code = '95';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoMNE.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoMNE.php
@@ -46,4 +46,6 @@ class LocaleInfoMNE extends LocaleInfo
     ];
 
     protected $currency_iso = 'EUR';
+    protected $phone_code = '382';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoMNG.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoMNG.php
@@ -45,4 +45,6 @@ class LocaleInfoMNG extends LocaleInfo
     ];
 
     protected $currency_iso = 'MNT';
+    protected $phone_code = '976';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoMOZ.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoMOZ.php
@@ -34,4 +34,6 @@ class LocaleInfoMOZ extends LocaleInfo
     ];
 
     protected $currency_iso = 'MZN';
+    protected $phone_code = '258';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoMRT.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoMRT.php
@@ -38,4 +38,6 @@ class LocaleInfoMRT extends LocaleInfo
     ];
 
     protected $currency_iso = 'MRU';
+    protected $phone_code = '222';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoMUS.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoMUS.php
@@ -40,4 +40,6 @@ class LocaleInfoMUS extends LocaleInfo
     ];
 
     protected $currency_iso = 'MUR';
+    protected $phone_code = '230';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoMWI.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoMWI.php
@@ -54,4 +54,6 @@ class LocaleInfoMWI extends LocaleInfo
     ];
 
     protected $currency_iso = 'MWK';
+    protected $phone_code = '265';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoMYS.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoMYS.php
@@ -39,4 +39,6 @@ class LocaleInfoMYS extends LocaleInfo
     ];
 
     protected $currency_iso = 'MYR';
+    protected $phone_code = '60';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoNAM.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoNAM.php
@@ -37,4 +37,6 @@ class LocaleInfoNAM extends LocaleInfo
     ];
 
     protected $currency_iso = 'NAD';
+    protected $phone_code = '264';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoNER.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoNER.php
@@ -29,4 +29,8 @@ class LocaleInfoNER extends LocaleInfo
         'Zinder',
         'Niamey',
     ];
+
+    protected $currency_iso = 'XOF';
+    protected $phone_code = '227';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoNGA.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoNGA.php
@@ -58,4 +58,7 @@ class LocaleInfoNGA extends LocaleInfo
         'YO' => 'Yobe',
         'ZA' => 'Zamfara',
     ];
+    protected $currency_iso = 'NGN';
+    protected $phone_code = '234';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoNIC.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoNIC.php
@@ -38,4 +38,8 @@ class LocaleInfoNIC extends LocaleInfo
         'RI' => 'Rivas',
         'SJ' => 'Río San Juan',
     ];
+
+    protected $currency_iso = 'NIO';
+    protected $phone_code = '505';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoNLD.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoNLD.php
@@ -33,4 +33,8 @@ class LocaleInfoNLD extends LocaleInfo
         'ZE' => 'Zeeland',
         'ZH' => 'Zuid-Holland',
     ];
+
+    protected $currency_iso = 'EUR';
+    protected $phone_code = '31';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoNOR.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoNOR.php
@@ -42,4 +42,7 @@ class LocaleInfoNOR extends LocaleInfo
         'Svalbard',
         'Jan Mayen',
     ];
+    protected $currency_iso = 'NOK';
+    protected $phone_code = '47';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoNPL.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoNPL.php
@@ -35,4 +35,8 @@ class LocaleInfoNPL extends LocaleInfo
         'SA' => 'Sagarmatha',
         'SE' => 'Seti',
     ];
+
+    protected $currency_iso = 'NPR';
+    protected $phone_code = '977';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoNRU.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoNRU.php
@@ -35,4 +35,8 @@ class LocaleInfoNRU extends LocaleInfo
         'Uaboe',
         'Yaren',
     ];
+
+    protected $currency_iso = 'AUD';
+    protected $phone_code = '674';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoNZL.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoNZL.php
@@ -27,13 +27,15 @@ class LocaleInfoNZL extends LocaleInfo
 
     protected $postcode_name = 'Postcode';
 
+    protected $currency_iso = 'NZD';
+    protected $phone_code = '64';
+
 
     /**
      * Validate address fields
      *
-     * @param Validator $valid Validator for the form being processed
+     * @param Validator $valid The validation object to add rules to
      * @param bool $required Are the address fields required?
-     * @return void
      */
     public function validateAddress(Validator $valid, $required = false)
     {
@@ -44,5 +46,3 @@ class LocaleInfoNZL extends LocaleInfo
     }
 
 }
-
-

--- a/src/sprout/Helpers/Locales/LocaleInfoOMN.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoOMN.php
@@ -32,4 +32,8 @@ class LocaleInfoOMN extends LocaleInfo
         'ZA' => 'Az Zāhirah',
         'ZU' => 'Z̧ufār',
     ];
+
+    protected $currency_iso = 'OMR';
+    protected $phone_code = '968';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoPAK.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoPAK.php
@@ -29,4 +29,8 @@ class LocaleInfoPAK extends LocaleInfo
         'SD' => 'Sindh',
         'TA' => 'Federally Administered Tribal Areas',
     ];
+
+    protected $currency_iso = 'PKR';
+    protected $phone_code = '92';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoPAN.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoPAN.php
@@ -34,4 +34,7 @@ class LocaleInfoPAN extends LocaleInfo
         'Kuna Yala',
         'Ngöbe-Buglé',
     ];
+    protected $currency_iso = 'PAB';
+    protected $phone_code = '507';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoPER.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoPER.php
@@ -47,4 +47,7 @@ class LocaleInfoPER extends LocaleInfo
         'TUM' => 'Tumbes',
         'UCA' => 'Ucayali',
     ];
+    protected $currency_iso = 'PEN';
+    protected $phone_code = '51';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoPHL.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoPHL.php
@@ -102,4 +102,7 @@ class LocaleInfoPHL extends LocaleInfo
         'Zambales',
         'Zamboanga Sibuguey',
     ];
+    protected $currency_iso = 'PHP';
+    protected $phone_code = '63';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoPLW.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoPLW.php
@@ -37,4 +37,7 @@ class LocaleInfoPLW extends LocaleInfo
         'Peleliu     ',
         'Sonsorol    ',
     ];
+    protected $currency_iso = 'USD';
+    protected $phone_code = '680';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoPNG.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoPNG.php
@@ -43,4 +43,7 @@ class LocaleInfoPNG extends LocaleInfo
         'WHM' => 'Western Highlands',
         'WPD' => 'Western',
     ];
+    protected $currency_iso = 'PGK';
+    protected $phone_code = '675';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoPOL.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoPOL.php
@@ -37,4 +37,7 @@ class LocaleInfoPOL extends LocaleInfo
         'WP' => 'Wielkopolskie',
         'ZP' => 'Zachodniopomorskie',
     ];
+    protected $currency_iso = 'PLN';
+    protected $phone_code = '48';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoPRK.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoPRK.php
@@ -32,4 +32,7 @@ class LocaleInfoPRK extends LocaleInfo
         'Yanggang-do',
         'Nasǒn',
     ];
+    protected $currency_iso = 'KPW';
+    protected $phone_code = '850';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoPRT.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoPRT.php
@@ -41,4 +41,7 @@ class LocaleInfoPRT extends LocaleInfo
         'Região Autónoma dos Açores',
         'Região Autónoma da Madeira',
     ];
+    protected $currency_iso = 'EUR';
+    protected $phone_code = '351';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoPRY.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoPRY.php
@@ -39,4 +39,7 @@ class LocaleInfoPRY extends LocaleInfo
         'Paraguarí',
         'Asunción',
     ];
+    protected $currency_iso = 'PYG';
+    protected $phone_code = '595';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoPSE.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoPSE.php
@@ -36,4 +36,8 @@ class LocaleInfoPSE extends LocaleInfo
         'TBS' => 'Tubas',
         'TKM' => 'Tulkarm',
     ];
+
+    protected $currency_iso = 'ILS';
+    protected $phone_code = '970';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoQAT.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoQAT.php
@@ -28,4 +28,8 @@ class LocaleInfoQAT extends LocaleInfo
         'WA' => 'Al Wakrah',
         'ZA' => 'Az̧ Z̧a‘āyin',
     ];
+
+    protected $currency_iso = 'QAR';
+    protected $phone_code = '974';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoROU.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoROU.php
@@ -63,4 +63,7 @@ class LocaleInfoROU extends LocaleInfo
         'VN' => 'Vrancea',
         'VS' => 'Vaslui',
     ];
+    protected $currency_iso = 'RON';
+    protected $phone_code = '40';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoRUS.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoRUS.php
@@ -104,4 +104,7 @@ class LocaleInfoRUS extends LocaleInfo
         'YEV' => 'Yevreyskaya avtonomnaya oblast\'',
         'ZAB' => 'Zabaykal\'skiy kray',
     ];
+    protected $currency_iso = 'RUB';
+    protected $phone_code = '7';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoRWA.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoRWA.php
@@ -26,4 +26,8 @@ class LocaleInfoRWA extends LocaleInfo
         'Ouest',
         'Sud',
     ];
+
+    protected $currency_iso = 'RWF';
+    protected $phone_code = '250';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoSAU.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoSAU.php
@@ -34,4 +34,7 @@ class LocaleInfoSAU extends LocaleInfo
         'AI Jawf',
         '\'Asīr',
     ];
+    protected $currency_iso = 'SAR';
+    protected $phone_code = '966';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoSDN.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoSDN.php
@@ -39,4 +39,8 @@ class LocaleInfoSDN extends LocaleInfo
         'RS' => 'Al Baḩr al Aḩmar',
         'SI' => 'Sinnār',
     ];
+
+    protected $currency_iso = 'SDG';
+    protected $phone_code = '249';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoSEN.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoSEN.php
@@ -35,4 +35,8 @@ class LocaleInfoSEN extends LocaleInfo
         'TH' => 'Thiès',
         'ZG' => 'Ziguinchor',
     ];
+
+    protected $currency_iso = 'XOF';
+    protected $phone_code = '221';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoSGP.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoSGP.php
@@ -26,4 +26,8 @@ class LocaleInfoSGP extends LocaleInfo
         'South East',
         'South West',
     ];
+
+    protected $currency_iso = 'SGD';
+    protected $phone_code = '65';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoSHN.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoSHN.php
@@ -24,4 +24,8 @@ class LocaleInfoSHN extends LocaleInfo
         'HL' => 'Saint Helena',
         'TA' => 'Tristan da Cunha',
     ];
+
+    protected $currency_iso = 'SHP';
+    protected $phone_code = '290';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoSLB.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoSLB.php
@@ -31,4 +31,8 @@ class LocaleInfoSLB extends LocaleInfo
         'TE' => 'Temotu',
         'WE' => 'Western',
     ];
+
+    protected $currency_iso = 'SBD';
+    protected $phone_code = '677';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoSLE.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoSLE.php
@@ -25,4 +25,8 @@ class LocaleInfoSLE extends LocaleInfo
         'Southern',
         'Western Area',
     ];
+
+    protected $currency_iso = 'SLL';
+    protected $phone_code = '232';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoSLV.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoSLV.php
@@ -35,4 +35,8 @@ class LocaleInfoSLV extends LocaleInfo
         'UN' => 'La Unión',
         'US' => 'Usulután',
     ];
+
+    protected $currency_iso = 'USD';
+    protected $phone_code = '503';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoSMR.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoSMR.php
@@ -30,4 +30,8 @@ class LocaleInfoSMR extends LocaleInfo
         'Montegiardino  ',
         'Serravalle     ',
     ];
+
+    protected $currency_iso = 'EUR';
+    protected $phone_code = '378';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoSOM.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoSOM.php
@@ -39,4 +39,8 @@ class LocaleInfoSOM extends LocaleInfo
         'TO' => 'Togdheer',
         'WO' => 'Woqooyi Galbeed',
     ];
+
+    protected $currency_iso = 'SOS';
+    protected $phone_code = '252';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoSRB.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoSRB.php
@@ -53,4 +53,7 @@ class LocaleInfoSRB extends LocaleInfo
         'Kosovo-Metohija',
         'Vojvodina',
     ];
+    protected $currency_iso = 'RSD';
+    protected $phone_code = '381';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoSSD.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoSSD.php
@@ -31,4 +31,8 @@ class LocaleInfoSSD extends LocaleInfo
         'UY' => 'Unity',
         'WR' => 'Warrap',
     ];
+
+    protected $currency_iso = 'SSP';
+    protected $phone_code = '211';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoSTP.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoSTP.php
@@ -23,4 +23,7 @@ class LocaleInfoSTP extends LocaleInfo
         'Príncipe',
         'São Tomé',
     ];
+    protected $currency_iso = 'STN';
+    protected $phone_code = '239';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoSUR.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoSUR.php
@@ -31,4 +31,8 @@ class LocaleInfoSUR extends LocaleInfo
         'SI' => 'Sipaliwini',
         'WA' => 'Wanica',
     ];
+
+    protected $currency_iso = 'SRD';
+    protected $phone_code = '597';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoSVK.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoSVK.php
@@ -29,4 +29,8 @@ class LocaleInfoSVK extends LocaleInfo
         'TC' => 'Trenčiansky kraj',
         'ZI' => 'Žilinský kraj',
     ];
+
+    protected $currency_iso = 'EUR';
+    protected $phone_code = '421';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoSVN.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoSVN.php
@@ -232,4 +232,8 @@ class LocaleInfoSVN extends LocaleInfo
         'Šentrupert',
         'Mirna',
     ];
+
+    protected $currency_iso = 'EUR';
+    protected $phone_code = '386';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoSWE.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoSWE.php
@@ -42,4 +42,7 @@ class LocaleInfoSWE extends LocaleInfo
         'Y' => 'Västernorrlands län',
         'Z' => 'Jämtlands län',
     ];
+    protected $currency_iso = 'SEK';
+    protected $phone_code = '46';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoSWZ.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoSWZ.php
@@ -25,4 +25,8 @@ class LocaleInfoSWZ extends LocaleInfo
         'MA' => 'Manzini',
         'SH' => 'Shiselweni',
     ];
+
+    protected $currency_iso = 'SZL';
+    protected $phone_code = '268';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoSYC.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoSYC.php
@@ -46,4 +46,7 @@ class LocaleInfoSYC extends LocaleInfo
         'Lemamel',
         'Ros Kaiman',
     ];
+    protected $currency_iso = 'SCR';
+    protected $phone_code = '248';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoSYR.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoSYR.php
@@ -35,4 +35,8 @@ class LocaleInfoSYR extends LocaleInfo
         'SU' => 'As Suwaydā\'',
         'TA' => 'Ţarţūs',
     ];
+
+    protected $currency_iso = 'SYP';
+    protected $phone_code = '963';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoTCD.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoTCD.php
@@ -44,4 +44,7 @@ class LocaleInfoTCD extends LocaleInfo
         'TI' => 'Tibastī',
         'WF' => 'Wadi Fira',
     ];
+    protected $currency_iso = 'XAF';
+    protected $phone_code = '235';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoTGO.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoTGO.php
@@ -26,4 +26,8 @@ class LocaleInfoTGO extends LocaleInfo
         'Plateaux',
         'Savannes',
     ];
+
+    protected $currency_iso = 'XOF';
+    protected $phone_code = '228';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoTHA.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoTHA.php
@@ -99,4 +99,7 @@ class LocaleInfoTHA extends LocaleInfo
         'Narathiwat',
         'Phatthaya',
     ];
+    protected $currency_iso = 'THB';
+    protected $phone_code = '66';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoTJK.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoTJK.php
@@ -25,4 +25,8 @@ class LocaleInfoTJK extends LocaleInfo
         'KT' => 'Khatlon',
         'SU' => 'Sughd',
     ];
+
+    protected $currency_iso = 'TJS';
+    protected $phone_code = '992';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoTKM.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoTKM.php
@@ -27,4 +27,8 @@ class LocaleInfoTKM extends LocaleInfo
         'Mary',
         'Aşgabat',
     ];
+
+    protected $currency_iso = 'TMT';
+    protected $phone_code = '993';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoTLS.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoTLS.php
@@ -34,4 +34,8 @@ class LocaleInfoTLS extends LocaleInfo
         'OE' => 'Oecussi',
         'VI' => 'Viqueque',
     ];
+
+    protected $currency_iso = 'USD';
+    protected $phone_code = '670';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoTON.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoTON.php
@@ -26,4 +26,8 @@ class LocaleInfoTON extends LocaleInfo
         'Tongatapu',
         'Vava\'u',
     ];
+
+    protected $currency_iso = 'TOP';
+    protected $phone_code = '676';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoTTO.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoTTO.php
@@ -36,4 +36,7 @@ class LocaleInfoTTO extends LocaleInfo
         'TOB' => 'Tobago',
         'TUP' => 'Tunapuna-Piarco',
     ];
+    protected $currency_iso = 'TTD';
+    protected $phone_code = '1868';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoTUN.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoTUN.php
@@ -45,4 +45,7 @@ class LocaleInfoTUN extends LocaleInfo
         'Médenine',
         'Tataouine',
     ];
+    protected $currency_iso = 'TND';
+    protected $phone_code = '216';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoTUR.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoTUR.php
@@ -102,4 +102,7 @@ class LocaleInfoTUR extends LocaleInfo
         'Osmaniye',
         'Düzce',
     ];
+    protected $currency_iso = 'TRY';
+    protected $phone_code = '90';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoTUV.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoTUV.php
@@ -29,4 +29,8 @@ class LocaleInfoTUV extends LocaleInfo
         'NMG' => 'Nanumanga',
         'VAI' => 'Vaitupu',
     ];
+
+    protected $currency_iso = 'AUD';
+    protected $phone_code = '688';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoTWN.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoTWN.php
@@ -43,4 +43,7 @@ class LocaleInfoTWN extends LocaleInfo
         'TXG' => 'Taichung',
         'YUN' => 'Yunlin',
     ];
+    protected $currency_iso = 'TWD';
+    protected $phone_code = '886';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoTZA.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoTZA.php
@@ -51,4 +51,7 @@ class LocaleInfoTZA extends LocaleInfo
         'Njombe',
         'Simiyu',
     ];
+    protected $currency_iso = 'TZS';
+    protected $phone_code = '255';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoUGA.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoUGA.php
@@ -123,4 +123,7 @@ class LocaleInfoUGA extends LocaleInfo
         'Rubirizi',
         'Sheema',
     ];
+    protected $currency_iso = 'UGX';
+    protected $phone_code = '256';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoUKR.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoUKR.php
@@ -48,4 +48,7 @@ class LocaleInfoUKR extends LocaleInfo
         'Chernihivska oblast',
         'Chernivetska oblast',
     ];
+    protected $currency_iso = 'UAH';
+    protected $phone_code = '380';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoUMI.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoUMI.php
@@ -30,4 +30,8 @@ class LocaleInfoUMI extends LocaleInfo
         'Kingman Reef',
         'Palmyra Atoll',
     ];
+
+    protected $currency_iso = 'USD';
+    protected $phone_code = '1';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoURY.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoURY.php
@@ -40,4 +40,7 @@ class LocaleInfoURY extends LocaleInfo
         'TA' => 'Tacuarembó',
         'TT' => 'Treinta y Tres',
     ];
+    protected $currency_iso = 'UYU';
+    protected $phone_code = '598';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoUSA.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoUSA.php
@@ -81,6 +81,8 @@ class LocaleInfoUSA extends LocaleInfo
 
     protected $postcode_name = 'ZIP Code';
 
+    protected $currency_iso = 'USD';
+    protected $phone_code = '+1';
 
     /**
      * Validate a ZIP Code, as a 5-digit number with an optional appended hyphen with 4 additional digits
@@ -112,6 +114,5 @@ class LocaleInfoUSA extends LocaleInfo
         // Parent validation checks for postcode length <= 10, so don't double up the max length error message
         $valid->check('postcode', 'Validity::length', 5, PHP_INT_MAX);
     }
+
 }
-
-

--- a/src/sprout/Helpers/Locales/LocaleInfoUZB.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoUZB.php
@@ -36,4 +36,8 @@ class LocaleInfoUZB extends LocaleInfo
         'TO' => 'Toshkent',
         'XO' => 'Xorazm',
     ];
+
+    protected $currency_iso = 'UZS';
+    protected $phone_code = '998';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoVCT.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoVCT.php
@@ -27,4 +27,8 @@ class LocaleInfoVCT extends LocaleInfo
         'Saint Patrick ',
         'Grenadines    ',
     ];
+
+    protected $currency_iso = 'XCD';
+    protected $phone_code = '1784';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoVEN.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoVEN.php
@@ -46,4 +46,8 @@ class LocaleInfoVEN extends LocaleInfo
         'Delta Amacuro',
         'Amazonas',
     ];
+
+    protected $currency_iso = 'VES';
+    protected $phone_code = '58';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoVNM.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoVNM.php
@@ -84,4 +84,7 @@ class LocaleInfoVNM extends LocaleInfo
         'Hai Phong',
         'Ho Chi Minh',
     ];
+    protected $currency_iso = 'VND';
+    protected $phone_code = '84';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoVUT.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoVUT.php
@@ -27,4 +27,8 @@ class LocaleInfoVUT extends LocaleInfo
         'TAE' => 'Taféa',
         'TOB' => 'Torba',
     ];
+
+    protected $currency_iso = 'VUV';
+    protected $phone_code = '678';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoWSM.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoWSM.php
@@ -32,4 +32,8 @@ class LocaleInfoWSM extends LocaleInfo
         'VF' => 'Va\'a-o-Fonoti',
         'VS' => 'Vaisigano',
     ];
+
+    protected $currency_iso = 'WST';
+    protected $phone_code = '685';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoYEM.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoYEM.php
@@ -43,4 +43,7 @@ class LocaleInfoYEM extends LocaleInfo
         'SU' => 'Arkhabīl Suquţrá',
         'TA' => 'Ta\'izz',
     ];
+    protected $currency_iso = 'YER';
+    protected $phone_code = '967';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoZAF.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoZAF.php
@@ -30,4 +30,8 @@ class LocaleInfoZAF extends LocaleInfo
         'NW' => 'North-West',
         'WC' => 'Western Cape',
     ];
+
+    protected $currency_iso = 'ZAR';
+    protected $phone_code = '27';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoZMB.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoZMB.php
@@ -31,4 +31,8 @@ class LocaleInfoZMB extends LocaleInfo
         'Lusaka',
         'Muchinga',
     ];
+
+    protected $currency_iso = 'ZMW';
+    protected $phone_code = '260';
+
 }

--- a/src/sprout/Helpers/Locales/LocaleInfoZWE.php
+++ b/src/sprout/Helpers/Locales/LocaleInfoZWE.php
@@ -31,4 +31,8 @@ class LocaleInfoZWE extends LocaleInfo
         'MV' => 'Masvingo',
         'MW' => 'Mashonaland West',
     ];
+
+    protected $currency_iso = 'ZWL';
+    protected $phone_code = '263';
+
 }

--- a/src/sprout/Helpers/Phones.php
+++ b/src/sprout/Helpers/Phones.php
@@ -156,12 +156,11 @@ class Phones
     public static function cleanNumber(string $number, $form = Normalizer::NFC): string
     {
         // First, remove all non-numeric characters except the plus sign
-        $number = trim($number);
+        $number = utf8::clean($number);
         $number = preg_replace('/[^0-9+]/', '', $number);
         $number = Normalizer::normalize($number, $form);
 
         $number = preg_replace(array_values(self::NORMALIZE), array_keys(self::NORMALIZE), $number);
-        $number = utf8::clean($number);
 
         return $number;
     }

--- a/src/sprout/Helpers/Phones.php
+++ b/src/sprout/Helpers/Phones.php
@@ -51,6 +51,24 @@ class Phones
 
 
     /**
+     * Get the default country code in alpha2 based on alpha3 core config
+     *
+     * @return string
+     */
+    private static function getDefaultCountryAlpha2(): string
+    {
+        static $default_country;
+        if ($default_country) {
+            return $default_country;
+        }
+
+        $alpha3 = Kohana::config('config.default_country_code');
+        $default_country = array_search($alpha3, CountryConstants::$alpha2to3);
+        return $default_country;
+    }
+
+
+    /**
      * Render a compound form field for a phone number. Data should come from `Form`
      *
      * <?php echo Phones::compoundFormField(true, 'Phone (mobile)'); ?>

--- a/src/sprout/Helpers/Phones.php
+++ b/src/sprout/Helpers/Phones.php
@@ -103,6 +103,11 @@ class Phones
      */
     public static function getCountryPhoneCodeOptions(): array
     {
+        static $codes;
+        if ($codes) {
+            return $codes;
+        }
+
         // Iterate all LocaleInfoXX classes to get phone codes and country names
         $codes = [];
         foreach (CountryConstants::$alpha3 as $code => $country_name) {
@@ -116,9 +121,11 @@ class Phones
         // Join US and Canada
         $codes['1'] = 'United States & Canada (+1)';
 
-        return array_filter($codes, function($k) {
+        $codes = array_filter($codes, function($k) {
             return !empty($k);
         }, ARRAY_FILTER_USE_KEY);
+
+        return $codes;
     }
 
 

--- a/src/sprout/Helpers/Phones.php
+++ b/src/sprout/Helpers/Phones.php
@@ -14,8 +14,10 @@
 namespace Sprout\Helpers;
 
 use Kohana;
+use Normalizer;
 use Sprout\Helpers\Locales\LocaleInfo;
 use Sprout\Helpers\PhpView;
+use utf8;
 
 /**
  * Helpers for common phone number functions
@@ -31,6 +33,20 @@ use Sprout\Helpers\PhpView;
 **/
 class Phones
 {
+    /**
+     * Normalisation patterns.
+     *
+     * https://www.php.net/manual/en/regexp.reference.unicode.php#128778
+     */
+    const NORMALIZE = [
+        ' ' => '/\s+/u',
+        '-' => '/\p{Pd}+/u',
+        '(' => '/\p{Ps}+/u',
+        ')' => '/\p{Pc}+/u',
+        '' => '/[\p{Cc}\p{Cf}]+/u',
+    ];
+
+
     /**
      * Render a compound form field for a phone number. Data should come from `Form`
      *
@@ -116,22 +132,49 @@ class Phones
      */
     public static function numberWithCountryCode(string $phone_number, string $phone_code): string
     {
-        $phone_number = self::cleanNumber($phone_number, $phone_code);
+        $phone_number = self::cleanStripCountryCode($phone_number, $phone_code);
         return "{$phone_code}{$phone_number}";
     }
 
 
     /**
-     * Clean a phone number by removing leading 0, +, 00, country code and non-numeric characters
+     * Trim, clean + normalise.
      *
-     * @param string $phone_number
-     * @param string $phone_code
+     * Our data can get pretty dirty. So dirty that our formatter/parser
+     * library can't do the basics.
+     *
+     * This doesn't normalise aggressively, only to get some characters codes
+     * into basic ASCII. We leave the rest to the parser.
+     *
+     * @param string $number
+     * @param int $form Normalizer::NFC
      * @return string
      */
-    public static function cleanNumber(string $phone_number, string $phone_code): string
+    public static function cleanNumber(string $number, $form = Normalizer::NFC): string
     {
         // First, remove all non-numeric characters except the plus sign
-        $phone_number = preg_replace('/[^0-9+]/', '', $phone_number);
+        $number = trim($number);
+        $number = preg_replace('/[^0-9+]/', '', $number);
+        $number = Normalizer::normalize($number, $form);
+
+        $number = preg_replace(array_values(self::NORMALIZE), array_keys(self::NORMALIZE), $number);
+        $number = utf8::clean($number);
+
+        return $number;
+    }
+
+
+    /**
+     * Clean a phone number then remove leading 0, +, 00, country code and non-numeric characters
+     *
+     * @param string $number
+     * @param string $phone_code
+     * @param int $form Normalizer::NFC
+     * @return string
+     */
+    public static function cleanStripCountryCode(string $number, string $phone_code, $form = Normalizer::NFC): string
+    {
+        $number = self::cleanNumber($number, $form);
 
         // Ensure we have a '+61' format code
         if (substr($phone_code, 0, 1) === '+') {
@@ -142,22 +185,22 @@ class Phones
         }
 
         // Trim country code from start of number if present as a number or a +code
-        if (str_starts_with($phone_number, $phone_code)) {
-            $phone_number = substr($phone_number, strlen($phone_code));
-        } elseif (str_starts_with($phone_number, $phone_code_no_plus)) {
-            $phone_number = substr($phone_number, strlen($phone_code_no_plus));
+        if (str_starts_with($number, $phone_code)) {
+            $number = substr($number, strlen($phone_code));
+        } elseif (str_starts_with($number, $phone_code_no_plus)) {
+            $number = substr($number, strlen($phone_code_no_plus));
         }
 
         // Check for leading double zeros (international format)
-        if (str_starts_with($phone_number, '00' . $phone_code_no_plus)) {
-            $phone_number = substr($phone_number, strlen('00' . $phone_code_no_plus));
+        if (str_starts_with($number, '00' . $phone_code_no_plus)) {
+            $number = substr($number, strlen('00' . $phone_code_no_plus));
         }
 
         // Remove leading 0
-        $phone_number = ltrim($phone_number, '0');
+        $number = ltrim($number, '0');
 
         // Remove any remaining non-numeric characters
-        return preg_replace('/[^0-9]/', '', $phone_number);
+        return preg_replace('/[^0-9]/', '', $number);
     }
 
     /**

--- a/src/sprout/Helpers/Phones.php
+++ b/src/sprout/Helpers/Phones.php
@@ -1,0 +1,200 @@
+<?php
+/*
+ * Copyright (C) 2024 Karmabunny Pty Ltd.
+ *
+ * This file is a part of SproutCMS.
+ *
+ * SproutCMS is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU General Public License as published by the Free Software Foundation, either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * For more information, visit <http://getsproutcms.com>.
+ */
+
+namespace Sprout\Helpers;
+
+use Kohana;
+use Sprout\Helpers\Locales\LocaleInfo;
+use Sprout\Helpers\PhpView;
+
+/**
+ * Helpers for common phone number functions
+ *
+ * RECOMMENDATION:
+ * In your data, store a `phone` and a `phone_code` side by side
+ * Use Phones::compoundFormField() to render a compound form field for a phone number
+ * Run the `phone` value through one of the `cleanNumber` helpers to get a clean number to store
+ *
+ * USAGE:
+ * Use the `Phones::compareNumbers()` helper to compare two phone numbers
+ * Use the `Phones::compareNumbersWithCode()` helper to compare two phone numbers by country code string
+**/
+class Phones
+{
+    /**
+     * Render a compound form field for a phone number. Data should come from `Form`
+     *
+     * <?php echo Phones::compoundFormField(true, 'Phone (mobile)'); ?>
+     *
+     * @param bool $required
+     * @param string $label
+     * @param array|null $field_names Optionally override the default field names [phone field, phone_code field]
+     * @param array|null $common Optionally override the default list of common country codes
+     * @return string
+     */
+    public static function compoundFormField(bool $required, string $label = null, ?array $field_names = null, ?array $common = null): string
+    {
+        $field_names = $field_names ?? ['phone', 'phone_code'];
+        $view = new PhpView('sprout/phone_field_compound');
+        $view->required = $required;
+        $view->label = $label;
+        $view->field_names = $field_names;
+        $view->common = $common;
+
+        return $view->render();
+    }
+
+
+    /**
+     * Get a list of country codes and their names for dropdown use
+     *
+     * @return array
+     */
+    public static function getCountryPhoneCodeOptions(): array
+    {
+        // Iterate all LocaleInfoXX classes to get phone codes and country names
+        $codes = [];
+        foreach (CountryConstants::$alpha3 as $code => $country_name) {
+            $class = "Sprout\Helpers\Locales\LocaleInfo{$code}";
+            if (class_exists($class)) {
+                $instance = new $class();
+                $codes[$instance->getPhoneCode()] = "{$country_name} (+{$instance->getPhoneCode()})";
+            }
+        }
+
+        // Join US and Canada
+        $codes['1'] = 'United States & Canada (+1)';
+
+        return array_filter($codes, function($k) {
+            return !empty($k);
+        }, ARRAY_FILTER_USE_KEY);
+    }
+
+
+    /**
+     * Get a list of country codes and their names
+     *
+     * Set common to an explicitly empty array `[]` for a single level list
+     *
+     * @param array|null $common Override the default list of common country codes, using alpha3 codes
+     * @return array
+     */
+    public static function countryPhoneCodeOptGroups(?array $common = null): array
+    {
+        $base_opts = self::getCountryPhoneCodeOptions();
+        if ($common === []) {
+            return $base_opts;
+        }
+
+        $common = $common ?? Kohana::config('config.common_phone_codes');
+        $common_codes = array_intersect_key($base_opts, array_flip($common));
+        $other_codes = array_diff_key($base_opts, $common_codes);
+
+        return [
+            'Popular' => $common_codes,
+            'Others' => $other_codes,
+        ];
+    }
+
+
+    /**
+     * Add a country phone code to a phone number
+     *
+     * @param string $phone_number
+     * @param string $phone_code
+     * @return string
+     */
+    public static function numberWithCountryCode(string $phone_number, string $phone_code): string
+    {
+        $phone_number = self::cleanNumber($phone_number, $phone_code);
+        return "{$phone_code}{$phone_number}";
+    }
+
+
+    /**
+     * Clean a phone number by removing leading 0, +, 00, country code and non-numeric characters
+     *
+     * @param string $phone_number
+     * @param string $phone_code
+     * @return string
+     */
+    public static function cleanNumber(string $phone_number, string $phone_code): string
+    {
+        // First, remove all non-numeric characters except the plus sign
+        $phone_number = preg_replace('/[^0-9+]/', '', $phone_number);
+
+        // Ensure we have a '+61' format code
+        if (substr($phone_code, 0, 1) === '+') {
+            $phone_code_no_plus = substr($phone_code, 1);
+        } else {
+            $phone_code_no_plus = $phone_code;
+            $phone_code = "+{$phone_code}";
+        }
+
+        // Trim country code from start of number if present as a number or a +code
+        if (str_starts_with($phone_number, $phone_code)) {
+            $phone_number = substr($phone_number, strlen($phone_code));
+        } elseif (str_starts_with($phone_number, $phone_code_no_plus)) {
+            $phone_number = substr($phone_number, strlen($phone_code_no_plus));
+        }
+
+        // Check for leading double zeros (international format)
+        if (str_starts_with($phone_number, '00' . $phone_code_no_plus)) {
+            $phone_number = substr($phone_number, strlen('00' . $phone_code_no_plus));
+        }
+
+        // Remove leading 0
+        $phone_number = ltrim($phone_number, '0');
+
+        // Remove any remaining non-numeric characters
+        return preg_replace('/[^0-9]/', '', $phone_number);
+    }
+
+    /**
+     * Compare two phone numbers, using default config country code
+     *
+     * Note: it's better to specify your country code wherever possible, using self::compareWithCode
+     *
+     * @param string $number_1
+     * @param string $number_2
+     * @return bool Whether the numbers are the same
+     */
+    public static function compareNumbers(string $number_1, string $number_2): bool
+    {
+        // Use the local default country code in case it's present
+        $locale =  LocaleInfo::get(Kohana::config('config.default_country_code'));
+        $clean_1 = self::numberWithCountryCode($number_1, $locale->getPhoneCode());
+        $clean_2 = self::numberWithCountryCode($number_2, $locale->getPhoneCode());
+
+        return $clean_1 === $clean_2;
+    }
+
+
+    /**
+     * Compare two phone numbers by their clean numbers, using country code strings
+     *
+     * @param string $number_1
+     * @param string $code_1
+     * @param string $number_2
+     * @param string $code_2
+     * @return bool Whether the numbers are the same
+     */
+    public static function compareWithCode(string $number_1, string $code_1, string $number_2, string $code_2): bool
+    {
+        $clean_1 = self::numberWithCountryCode($number_1, $code_1);
+        $clean_2 = self::numberWithCountryCode($number_2, $code_2);
+
+        return $clean_1 === $clean_2;
+    }
+
+}

--- a/src/sprout/config/config.php
+++ b/src/sprout/config/config.php
@@ -33,6 +33,13 @@ require_once DOCROOT . 'config/config.php';
 $config['site_protocol'] = '';
 
 /**
+ * Default ISO3 country code for phone numbers and other geo-specific things
+ *
+ * If not set, it will default to 'AUS'
+ */
+$config['default_country_code'] = 'AUS';
+
+/**
  * Name of the front controller for this application. Default: index.php
  *
  * This can be removed by using URL rewriting.

--- a/src/sprout/config/config.php
+++ b/src/sprout/config/config.php
@@ -40,6 +40,27 @@ $config['site_protocol'] = '';
 $config['default_country_code'] = 'AUS';
 
 /**
+ * Common country codes for phone numbers or other forms
+ *
+ * This is a list of country codes that are commonly used in Australia
+ * and can be amended for your use case
+ *
+ * Make this empty to render phone codes as a single level list
+ */
+$config['common_phone_codes'] = [
+    '61', // Australia
+    '86', // China
+    '1', // Canada
+    '91', // India
+    '44', // Ireland
+    '64', // New Zealand
+    '92', // Pakistan
+    '27', // South Africa
+    '44', // United Kingdom
+    '1', // United States
+];
+
+/**
  * Name of the front controller for this application. Default: index.php
  *
  * This can be removed by using URL rewriting.

--- a/src/sprout/views/phone_field_compound.php
+++ b/src/sprout/views/phone_field_compound.php
@@ -1,0 +1,27 @@
+
+<?php
+
+use Sprout\Helpers\Form;
+use Sprout\Helpers\Phones;
+
+?>
+
+<div class="field-element field-element--text field-element--required">
+    <div class="field-label">
+        <label for="field0"><?php echo $label ?? 'Phone (mobile)'; ?>
+            <?php if ($required) { ?>
+                <span class="field-label__required">required</span>
+            <?php } ?>
+        </label>
+    </div>
+    <div class="field-input">
+        <div class="row">
+            <div class="col-xs-12 col-sm-4 col-md-3">
+                <?php echo Form::dropdown($field_names[1], ['-dropdown-top' => 'Country'], Phones::countryPhoneCodeOptGroups($common)); ?>
+            </div>
+            <div class="col-xs-12 col-sm-8 col-md-9">
+                <?php echo Form::number($field_names[0], ['placeholder' => 'Phone number']); ?>
+            </div>
+        </div>
+    </div>
+</div>

--- a/tests/PhonesTest.php
+++ b/tests/PhonesTest.php
@@ -82,7 +82,7 @@ class PhonesTest extends TestCase
      */
     public function testCleanPhoneNumber(string $dirty, string $phone_code, string $clean)
     {
-        $this->assertEquals($clean, Phones::cleanNumber($dirty, $phone_code));
+        $this->assertEquals($clean, Phones::cleanStripCountryCode($dirty, $phone_code));
     }
 
 

--- a/tests/PhonesTest.php
+++ b/tests/PhonesTest.php
@@ -1,0 +1,173 @@
+<?php
+/*
+ * Copyright (C) 2025 Karmabunny Pty Ltd.
+ *
+ * This file is a part of SproutCMS.
+ *
+ * SproutCMS is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU General Public License as published by the Free Software Foundation, either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * For more information, visit <http://getsproutcms.com>.
+ */
+
+use PHPUnit\Framework\TestCase;
+use Sprout\Helpers\Phones;
+
+/**
+ * Test suite for the Phones helper class
+ */
+class PhonesTest extends TestCase
+{
+
+    /**
+     * Test country code list. Will auto-populate if first run
+     *
+     * @return void
+     */
+    public function testCompoundFormField()
+    {
+        $html = Phones::compoundFormField(true, 'Phone (mobile)', ['phone', 'phone_code']);
+        $this->assertStringContainsString('Phone (mobile)', $html);
+        $this->assertStringContainsString('+61', $html);
+        $this->assertStringContainsString('"61"', $html);
+        $this->assertStringContainsString('+64', $html);
+        $this->assertStringContainsString('"64"', $html);
+        $this->assertStringContainsString('+44', $html);
+        $this->assertStringContainsString('"44"', $html);
+    }
+
+    /**
+     * Test country code list. Will auto-populate if first run
+     *
+     * @return void
+     */
+    public function testCompoundFormFieldWithCustomFieldNames()
+    {
+        $html = Phones::compoundFormField(true, 'Phone (mobile)', ['phone_number_jumper', 'boogie_woogie']);
+        $this->assertStringContainsString('class="dropdown" name="boogie_woogie"', $html);
+        $this->assertStringContainsString('name="phone_number_jumper"', $html);
+        $this->assertStringContainsString('name="boogie_woogie"', $html);
+    }
+
+
+    public function dataProviderCleanPhoneNumber()
+    {
+        return [
+            'leading code' => ['+61491570156', '+61', '491570156'],
+            'leading 0' => ['0491570156', '+61', '491570156'],
+            'no leading 0' => ['491570156', '+61', '491570156'],
+            'leading code 2' => ['+642102468429', '+64', '2102468429'],
+            'leading 0 2' => ['02102468429', '+64', '2102468429'],
+            'no leading 0 2' => ['2102468429', '+64', '2102468429'],
+            'leading double 0' => ['0061491570156', '+61', '491570156'],
+            'leading double 0 2' => ['00642102468429', '+64', '2102468429'],
+            'with spaces' => ['0491 570 156', '+61', '491570156'],
+            'with dashes' => ['0491-570-156', '+61', '491570156'],
+            'with parentheses' => ['(0491) 570 156', '+61', '491570156'],
+            'with country code no plus' => ['61491570156', '+61', '491570156'],
+            'with mixed formatting' => ['+61 (0) 491-570-156', '+61', '491570156'],
+            'with letters' => ['0491ABC570156', '+61', '491570156'],
+            'with phone code without plus' => ['61491570156', '61', '491570156'],
+            'with international format and spaces' => ['+61 491 570 156', '+61', '491570156'],
+            'with triple zero prefix' => ['000491570156', '+61', '491570156'],
+            'empty string' => ['', '+61', ''],
+            'non-numeric only' => ['(+*&)', '+61', ''],
+        ];
+    }
+
+
+    /**
+     * @dataProvider dataProviderCleanPhoneNumber
+     */
+    public function testCleanPhoneNumber(string $dirty, string $phone_code, string $clean)
+    {
+        $this->assertEquals($clean, Phones::cleanNumber($dirty, $phone_code));
+    }
+
+
+    /**
+     * @dataProvider dataProviderCleanPhoneNumber
+     */
+    public function testPhoneNumberWithCountryCodeString(string $dirty, string $phone_code, string $clean)
+    {
+        $this->assertEquals("{$phone_code}{$clean}", Phones::numberWithCountryCode($dirty, $phone_code));
+    }
+
+
+    public function dataProviderCompareCleanNumbers()
+    {
+        return [
+            'same number' => ['+61491570156', '+61491570156', true],
+            'same number different code' => ['+61491570156', '+64491570156', false],
+            'different number same code' => ['+61491570156', '+61491570157', false],
+            'same number no code' => ['0491570156', '0491570156', true],
+            'same number no code 2' => ['491570156', '491570156', true],
+            'formatted vs unformatted' => ['+61 491 570 156', '+61491570156', true],
+            'with dashes' => ['+61-491-570-156', '+61491570156', true],
+            'with parentheses' => ['+61 (0) 491 570 156', '+61491570156', true],
+            'with letters' => ['+61491ABC570156', '+61491570156', true],
+            'empty strings' => ['', '', true],
+            'non-numeric only' => ['(+*&)', '', true],
+            'leading zero vs country code' => ['0491570156', '+61491570156', true],
+            'different formatting but same number' => ['(04) 9157-0156', '0491 570 156', true],
+            'spaces vs no spaces' => ['0491 570 156', '0491570156', true],
+            'double zero prefix vs country code' => ['0061491570156', '+61491570156', true],
+        ];
+    }
+
+
+    /**
+     * @dataProvider dataProviderCompareCleanNumbers
+     */
+    public function testCompareCleanNumbers(string $number_1, string $number_2, bool $expected)
+    {
+        $this->assertEquals($expected, Phones::compareNumbers($number_1, $number_2));
+    }
+
+
+    public function dataProviderCompareCleanNumbersWithCodeString()
+    {
+        return [
+            'same number' => ['+61491570156', '+61', '+61491570156', '+61', true],
+            'same number different code' => ['+61491570156', '+61', '+64491570156', '+64', false],
+            'different number same code' => ['+61491570156', '+61', '+61491570157', '+61', false],
+            'same number with leading zero' => ['0491570156', '+61', '+61491570156', '+61', true],
+            'same number with spaces and formatting' => ['+61 491 570 156', '+61', '+61491570156', '+61', true],
+            'same number with dashes' => ['+61-491-570-156', '+61', '+61491570156', '+61', true],
+            'same number with parentheses' => ['+61 (0) 491 570 156', '+61', '+61491570156', '+61', true],
+            'same number with letters' => ['+61491ABC570156', '+61', '+61491570156', '+61', true],
+            'empty strings' => ['', '+61', '', '+61', true],
+            'non-numeric only' => ['(+*&)', '+61', '', '+61', true],
+            'different codes but same number after cleaning' => ['0491570156', '+61', '0491570156', '+64', false],
+            'different formatting but same number' => ['(04) 9157-0156', '+61', '0491 570 156', '+61', true],
+        ];
+    }
+
+
+    /**
+     * @dataProvider dataProviderCompareCleanNumbersWithCodeString
+     */
+    public function testCompareCleanNumbersWithCodeString(string $number_1, string $code_1, string $number_2, string $code_2, bool $expected)
+    {
+        $this->assertEquals($expected, Phones::compareWithCode($number_1, $code_1, $number_2, $code_2));
+    }
+
+
+    public function dataProviderCompareCleanNumbersWithCountryCodeId()
+    {
+        return [
+            'same number' => ['+61491570156', 'AUS', '+61491570156', 'AUS', true],
+            'same number different code' => ['+61491570156', 'AUS', '+64491570156', 'NZL', false],
+            'different number same code' => ['+61491570156', 'AUS', '+61491570157', 'AUS', false],
+            'same number with leading zero' => ['0491570156', 'AUS', '+61491570156', 'AUS', true],
+            'same number with spaces and formatting' => ['+61 491 570 156', 'AUS', '+61491570156', 'AUS', true],
+            'same number with dashes' => ['+61-491-570-156', 'AUS', '+61491570156', 'AUS', true],
+            'same number with parentheses' => ['+61 (0) 491 570 156', 'AUS', '+61491570156', 'AUS', true],
+            'same number with letters' => ['+61491ABC570156', 'AUS', '+61491570156', 'AUS', true],
+            'empty strings' => ['', 'AUS', '', 'AUS', true],
+            'non-numeric only' => ['(+*&)', 'AUS', '', 'AUS', true],
+        ];
+    }
+
+}


### PR DESCRIPTION
Adds helpers for handling phones with and without country codes. Adds phones country codes to core local helpers

Also includes a port of the Numbers.php helper by @gwillz with some modifications and additional unit tests.
This allows you to deal with phones directly, or using the provided lib.

Includes a compound phone field form element. This assumes usage of Flexbox, could use an over-writable template one day.

Phone codes generated with Windsurf, cross checked with Gemini

![image](https://github.com/user-attachments/assets/0cbe4d4e-86f1-4189-987f-34e22042f895)
