### PR TITLE
Resolve race conditions for admin locks

### DIFF
--- a/src/sprout/Helpers/Admin.php
+++ b/src/sprout/Helpers/Admin.php
@@ -14,7 +14,7 @@
 namespace Sprout\Helpers;
 
 use Exception;
-
+use karmabunny\pdb\Exceptions\ConstraintQueryException;
 use Kohana;
 
 use karmabunny\pdb\Exceptions\QueryException;
@@ -851,8 +851,7 @@ class Admin
      * Gets the lock details for a given record
      * @param string $ctlr Controller name
      * @param int $record_id DB record ID
-     * @return array If locked; has keys 'id', 'operator_name', 'lock_key', 'date_modified'
-     * @return null If not locked
+     * @return array|null If locked; has keys 'id', 'operator_name', 'lock_key', 'date_modified'
      **/
     public static function getLock($ctlr, $record_id)
     {
@@ -883,7 +882,7 @@ class Admin
      * @param string $ctlr The controller responsible for the record
      * @param int $record_id The record ID
      * @throws Exception If the lock fails to acquire
-     * @return int Lock id
+     * @return int|null Lock ID if the lock was acquired, null if it was already held
      */
     public static function lock($ctlr, $record_id)
     {
@@ -905,11 +904,12 @@ class Admin
 
         try {
             $lock_id = Pdb::insert('admin_locks', $update_data);
+            return $lock_id;
+        } catch (ConstraintQueryException $ex) {
+            return null;
         } catch (Exception $ex) {
-            throw new Exception('Failed to acquire edit lock: ' . $ex->getMessage());
+            throw new Exception('Failed to acquire edit lock: ' . $ex->getMessage(), 0, $ex);
         }
-
-        return $lock_id;
     }
 
 


### PR DESCRIPTION
Using a constraint exception is the only (simple) way to atomically verify a key or create a new one in it's place.

Really quite hard to test this one. Just guess we need to run it on project that gets these errors a lot.

