### PR TITLE
PHP 8.4 compatibility: fix implicit null arguments

### DIFF
--- a/src/sprout/Helpers/FilesBackend.php
+++ b/src/sprout/Helpers/FilesBackend.php
@@ -173,7 +173,7 @@ abstract class FilesBackend {
      * @param int $ttl Number of seconds to hold cache for. Defaults to one day
      * @return void
      */
-    public function setCacheResponse(string $function, string $filename, $response, int $ttl = null): void
+    public function setCacheResponse(string $function, string $filename, $response, ?int $ttl = null): void
     {
         if (!Kohana::config('cache.enabled')) return;
 

--- a/src/sprout/Helpers/ImportCSV.php
+++ b/src/sprout/Helpers/ImportCSV.php
@@ -34,7 +34,7 @@ class ImportCSV
      * @param array|null $headings Headings for the columns in the CSV.
      *        If not provided, they will be extracted from the first row of the CSV
      */
-    public function __construct($filename, array $headings = null)
+    public function __construct($filename, ?array $headings = null)
     {
         if (is_string($filename)) {
             $this->handle = @fopen($filename, 'r');
@@ -96,5 +96,3 @@ class ImportCSV
     }
 
 }
-
-

--- a/src/sprout/Helpers/Phones.php
+++ b/src/sprout/Helpers/Phones.php
@@ -83,7 +83,7 @@ class Phones
      * @param array|null $common Optionally override the default list of common country codes
      * @return string
      */
-    public static function compoundFormField(bool $required, string $label = null, ?array $field_names = null, ?array $common = null): string
+    public static function compoundFormField(bool $required, ?string $label = null, ?array $field_names = null, ?array $common = null): string
     {
         $field_names = $field_names ?? ['phone', 'phone_code'];
         $view = new PhpView('sprout/phone_field_compound');


### PR DESCRIPTION
Implicitly nullable parameter types are deprecated in PHP 8.4