### PR TITLE
Feat/recaptcha3 min score

### DIFF
--- a/src/sprout/Helpers/Recaptcha3.php
+++ b/src/sprout/Helpers/Recaptcha3.php
@@ -52,6 +52,7 @@ class Recaptcha3
     /**
      * Checks the captcha field against the submitted text
      *
+     * @param float $min_score Minimum score required (default: 0.2)
      * @throws Exception On invalid response
      * @return boolean True on success
      */


### PR DESCRIPTION
Simple change to allow override of min score needed to pass recaptcha3

Backwards compatible with existing behaviour
Adds some return types for good measure

Would be nice to make it not rely on $_POST (e.g. when using decoded JSON payloads)
but I don't want to break anything with that