### PR TITLE
Fix for deprecated single arg init for ReflectionMethod in 8.4

### DIFF
--- a/src/sprout/Helpers/Form.php
+++ b/src/sprout/Helpers/Form.php
@@ -602,8 +602,12 @@ class Form
     {
         $use_fieldset = false;
 
-        $args = explode('::', $method);
-        $func = new ReflectionMethod($args[0], $args[1]);
+        if (is_string($method) and strpos($method, '::') !== false) {
+            $func = new ReflectionMethod(...explode('::', $method));
+        } else {
+            $func = new ReflectionMethod($method);
+        }
+
         $comment = $func->getDocComment();
         if ($comment and strpos($comment, '@wrap-in-fieldset') !== false) {
             $use_fieldset = true;


### PR DESCRIPTION
Fixes broken Form tooling where we pass `Fb::dropdown` etc as a single arg - deprecated behaviour in PHP 8.4