### PR TITLE
Sensible handling of non-deletable items in admin ctlr

### DIFF
--- a/src/sprout/Controllers/AdminController.php
+++ b/src/sprout/Controllers/AdminController.php
@@ -1710,7 +1710,10 @@ class AdminController extends Controller
 
         if (!$this->checkAccess($ctlr, 'delete', false)) return;
         if (!$this->checkRecordAccess($ctlr, $id)) return;
-        if (!$ctlr->_isDeleteSaved($id)) return;
+        if (!$ctlr->_isDeleteSaved($id)) {
+            Notification::error('This item cannot be deleted');
+            Url::redirect("admin/edit/{$type}/{$id}");
+        }
 
         $main = $ctlr->_getDeleteForm($id);
         if ($main instanceof AdminError) {


### PR DESCRIPTION
If an item can't be deleted it renders a fairly useless blank screen. This replaces that with an error message and redirect to the item.