### PR TITLE
Add native return type on Url::redirect

### DIFF
--- a/src/sprout/Helpers/Url.php
+++ b/src/sprout/Helpers/Url.php
@@ -169,7 +169,7 @@ class Url
      * @return never
      * @throws LogicException
      */
-    public static function redirect($uri = '', $method = '302')
+    public static function redirect($uri = '', $method = '302'): never
     {
         if (Events::hasRun(Kohana::class, SendHeadersEvent::class)) {
 


### PR DESCRIPTION
Otherwise PHPStorm complains when functions that call it are set to return never