### PR TITLE
Fix worker queue issues

### DIFF
--- a/src/sprout/Helpers/WorkerCtrl.php
+++ b/src/sprout/Helpers/WorkerCtrl.php
@@ -389,7 +389,12 @@ class WorkerCtrl
      *   'Prepared', 'Running', 'Success', 'Failed'.
      *
      * @param int $job_id
-     * @return array ['status', 'metric1val', 'metric2val', 'metric3val']
+     * @return array{
+     *     status: 'Prepared' | 'Running' | 'Success' | 'Failed',
+     *     metric1val: int,
+     *     metric2val: int,
+     *     metric3val: int,
+     * }
      */
     public static function getStatus($job_id): array
     {

--- a/src/sprout/Helpers/WorkerJob.php
+++ b/src/sprout/Helpers/WorkerJob.php
@@ -173,12 +173,11 @@ abstract class WorkerJob implements WorkerJobInterface, LogSinkInterface
                 continue;
             }
 
+            $type = $property->getType();
             if (
-                ($type = $property->getType()) instanceof ReflectionNamedType
-                and (
-                    (is_string($item) and class_exists($type->getName()))
-                    or (is_array($item) and $type->getName() === 'array')
-                )
+                $type instanceof ReflectionNamedType
+                and is_string($item)
+                and ($type->getName() === 'array' or class_exists($type->getName()))
             ) {
                 $item = unserialize($item);
             }

--- a/src/sprout/Helpers/WorkerQueue.php
+++ b/src/sprout/Helpers/WorkerQueue.php
@@ -102,6 +102,7 @@ class WorkerQueue implements ConfigurableInterface, QueueInterface
                     'code',
                     'class_name',
                     'args',
+                    'log',
                 ])
                 ->where([
                     'channel' => $this->channel,
@@ -119,11 +120,33 @@ class WorkerQueue implements ConfigurableInterface, QueueInterface
                 $class = $row['class_name'];
                 $args = Json::decode($row['args']);
 
-                if (is_subclass_of($class, WorkerJobInterface::class)) {
-                    $inst = $class::fromJson($args);
-                } else {
-                    $inst = Sprout::instance($class, JobInterface::class);
-                    Configure::update($inst, $args);
+                $inst = null;
+                try {
+                    if (is_subclass_of($class, WorkerJobInterface::class)) {
+                        $inst = $class::fromJson($args);
+                    } else {
+                        $inst = Sprout::instance($class, JobInterface::class);
+                        Configure::update($inst, $args);
+                    }
+                } catch (\Throwable $e) {
+                    // Mark job as having a fatal error
+                    $log_message = $row['log'];
+                    $time = '[' . date('h:i:s a') . ']';
+                    $error = get_class($e) . ': ' . $e->getMessage();
+                    $log_message .= "$time FATAL $error\n";
+                    $pdb->update(
+                        'worker_jobs',
+                        [
+                            'log' => $log_message,
+                            'status' => 'Failed',
+                            'date_failure' => $pdb->now(),
+                            'date_modified' => $pdb->now(),
+                            'pid' => 0,
+                        ],
+                        ['id' => $row['id']]
+                    );
+
+                    $inst = null;
                 }
 
                 if ($inst instanceof WorkerJob) {
@@ -132,7 +155,9 @@ class WorkerQueue implements ConfigurableInterface, QueueInterface
                     $inst->channel = $this->channel;
                 }
 
-                return $inst;
+                if (!empty($inst)) {
+                    return $inst;
+                }
             }
 
             sleep(1);


### PR DESCRIPTION
1. Job with an array property fails to run because arrays can't be `unserialize`d
2. If a bad job gets in the queue (e.g. class doesn't exist or fails to have its config applied, as per issue 1), the queue goes into an infinite loop trying to run the same job