### PR TITLE
Fixes file download method to actually use existing file if available

### DIFF
--- a/src/sprout/Controllers/FileController.php
+++ b/src/sprout/Controllers/FileController.php
@@ -330,11 +330,9 @@ class FileController extends Controller
             $resize_filename = FileTransform::getTransformFilename($filename, $size);
 
             // Use the resize if we're able.
-            if (!File::exists($resize_filename)
-                and File::createDefaultSize($id, $size)) {
+            if (File::exists($resize_filename)
+                or FileTransform::createDefaultTransform($id, $size)) {
                     $filename = $resize_filename;
-            } else if (File::exists($resize_filename)) {
-                $filename = $resize_filename;
             }
         }
 

--- a/src/sprout/Controllers/FileController.php
+++ b/src/sprout/Controllers/FileController.php
@@ -330,10 +330,10 @@ class FileController extends Controller
             $resize_filename = FileTransform::getTransformFilename($filename, $size);
 
             // Use the resize if we're able.
-            if (
-                !File::exists($resize_filename)
-                and File::createDefaultSize($id, $size)
-            ) {
+            if (!File::exists($resize_filename)
+                and File::createDefaultSize($id, $size)) {
+                    $filename = $resize_filename;
+            } else if (File::exists($resize_filename)) {
                 $filename = $resize_filename;
             }
         }


### PR DESCRIPTION
### Fixes file download method to actually use existing resized file when available

If the file already existed with requested resized, it never actually used the resized file. Serving the original (large) file.

It now serves the resized file as expected.