### PR TITLE
Feat/neon entities

### DIFF
--- a/src/module_template/admin_edit.example.neon
+++ b/src/module_template/admin_edit.example.neon
@@ -1,61 +1,66 @@
 tab-details:
-    - field:
+    - Field(
         name: 'first_name'
         label: 'Given name'
-        attrs:
-            id: 'admin-noobcakes-firstname'
-            placeholder: 'Frank'
-            data-xxx: ''
-
+        attrs: {
+            id: 'admin-noobcakes-firstname',
+            placeholder: 'Frank',
+            data-xxx: '',
+        }
         display: 'Fb::text'
 
         # Items are usually for radio/dropdown, but will be passed as an arg to any fb::-style function
         # Radio/Dropdown (inline)
-        items:
-            a: 'A'
-            b: 'B'
-
+        items: {
+            a: 'A',
+            b: 'B',
+        }
         # Radio/Dropdown (lookup)
         items2: 'MyHelper::myItems'
         required: true
 
         # don't save display values
         ignore: true
-        validate:
-            - {"func":"Val::personName"}
-            - {"func":"Val::len","args":[1,20]}
-            - {"func":"Slug::validateUnique","for":["edit"]}
+        validate: [
+            Val::personName(),
+            Val::len(1,20),
+            { func: Slug::validateUnique(), for: ['edit'] },
+        ]
+    )
 
-    - checkboxes:
+    - Checkboxes(
         label: ''
-        items:
-            name: 'label'
-            name2: 'label2'
+        items: {
+            name: 'label',
+            name2: 'label2',
+        }
+    )
 
-    - heading: ''
+    - Heading('')
 
-    - html: '<p>I like peanuts</p>'
+    - Html('<p>I like peanuts</p>')
 
-    - group:
-        - field: '_'
-        - field: '_'
+    - Group(
+        Field(name: 'item1')
+        Field(name: 'item2')
+    )
 
-    - custom:
-        display:
-            func: 'MyClass:myFunc'
-            args: ['-']
+    - Custom(
+        display: MyClass:myFunc
         save:
             func_: '// Takes an array of field => val, which fn modifies'
             func: 'MyClass:myFunc'
             args: ['-']
+    )
 
-    - multiedit:
+    - Multiedit(
         table: 'event_dates'
         where: 'Events::getFutureCondition'
         single: 'Date'
         items:
-            - field: '_'
-            - field: '_'
+            - Field(name: '_')
+            - Field(name: '_')
+    )
 
 second_tab: []
 Categories: 'categories'

--- a/src/sprout/Controllers/Controller.php
+++ b/src/sprout/Controllers/Controller.php
@@ -513,6 +513,8 @@ abstract class Controller extends BaseController
                     JsonForm::setParameterForColumns($items, $fk_cols, 'empty', '');
                 }
                 foreach ($items as &$item) {
+                    $item = JsonForm::parseEntityField($item);
+
                     if (isset($item['multiedit'])) {
                         $multiedits[] = &$item['multiedit'];
                     }

--- a/src/sprout/Controllers/DbToolsController.php
+++ b/src/sprout/Controllers/DbToolsController.php
@@ -2202,7 +2202,7 @@ class DbToolsController extends Controller
                 $items = "{}";
             }
 
-            $neon = "{$t}- field:\n" .
+            $neon = "{$t}- Field(\n" .
                 "{$t}{$t}name: \"{$f}\"\n" .
                 "{$t}{$t}label: \"{$l}\"\n" .
                 "{$t}{$t}display: \"{$input_method}\"\n" .
@@ -2215,13 +2215,14 @@ class DbToolsController extends Controller
             if (preg_match('/\([0-9]+(\s*,)?/', $type, $matches)) {
                 $field_len = (int) substr($matches[0], 1);
                 if (!empty($matches[1])) ++$field_len;
-                $neon .= "\n";
-                $neon .= "{$t}{$t}{$t}func: \"Validity::length\"\n";
-                $neon .= "{$t}{$t}{$t}args: [0, {$field_len}]\n";
+                $neon .= " [\n";
+                $neon .= "{$t}{$t}{$t}Validity::length(0, {$field_len})\n";
+                $neon .= "{$t}{$t}]\n";
             } else {
                 $neon .= " []\n";
             }
 
+            $neon .= "{$t})";
             $fields_neon[] = $neon;
 
             if (isset($inbuilt_fields[$f])) continue;
@@ -2688,7 +2689,7 @@ class DbToolsController extends Controller
                 }
                 $l = implode(' ', $l_parts);
 
-                $neon = "{$tab}- field:\n" .
+                $neon = "{$tab}- Field(\n" .
                     "{$tab}{$tab}name: \"{$f}\"\n" .
                     "{$tab}{$tab}label: \"{$l}\"\n" .
                     "{$tab}{$tab}display: \"{$input_method}\"\n" .
@@ -2701,13 +2702,14 @@ class DbToolsController extends Controller
                 if (preg_match('/\([0-9]+(\s*,)?/', $col->type, $matches)) {
                     $field_len = (int) substr($matches[0], 1);
                     if (!empty($matches[1])) ++$field_len;
-                    $neon .= "\n";
-                    $neon .= "{$tab}{$tab}{$tab}func: \"Validity::length\"\n";
-                    $neon .= "{$tab}{$tab}{$tab}args: [0, {$field_len}]\n";
+                    $neon .= " [\n";
+                    $neon .= "{$tab}{$tab}{$tab}Validity::length(0, {$field_len})\n";
+                    $neon .= "{$tab}{$tab}]\n";
                 } else {
                     $neon .= " []\n";
                 }
 
+                $neon .= "{$tab})\n";
                 $fields_neon[] = $neon;
 
                 $fields_manual[] = "<p><b>{$l}</b>\n<br><!-- description goes here --></p>\n";

--- a/src/sprout/Helpers/JsonForm.php
+++ b/src/sprout/Helpers/JsonForm.php
@@ -43,6 +43,8 @@ class JsonForm extends Form
             if (!is_array($tab_content)) continue;
 
             foreach ($tab_content as $item) {
+                $item = JsonForm::parseEntityField($item);
+
                 if (!isset($item['multiedit'])) continue;
 
                 $multed = $item['multiedit'];
@@ -118,6 +120,8 @@ class JsonForm extends Form
             if (!is_array($tab_content)) continue;
 
             foreach ($tab_content as $item) {
+                $item = JsonForm::parseEntityField($item);
+
                 if (!isset($item['autofill_list'])) continue;
 
                 $auto = $item['autofill_list'];
@@ -253,6 +257,17 @@ class JsonForm extends Form
     }
 
 
+    public static function parseEntityField(array|Entity $item)
+    {
+        if ($item instanceof Entity) {
+            $type = Inflector::underscore(strtolower($item->value));
+            $item = [ $type => $item->attributes ];
+        }
+
+        return $item;
+    }
+
+
     /**
      * Render a tab item, which may be a field, heading, html block, etc
      *
@@ -266,10 +281,7 @@ class JsonForm extends Form
      */
     public static function renderTabItem(array|Entity $item, $for, $id, array $data, array $errors, $name_prepend = '')
     {
-        if ($item instanceof Entity) {
-            $type = Inflector::underscore(strtolower($item->value));
-            $item = [ $type => $item->attributes ];
-        }
+        $item = self::parseEntityField($item);
 
         if ($field = $item['field'] ?? null) {
             return self::renderFieldItem($field, $for, $id, $data, $errors, $name_prepend);
@@ -509,6 +521,8 @@ class JsonForm extends Form
         $field_defns = [];
 
         foreach ($items as $item) {
+            $item = JsonForm::parseEntityField($item);
+
             if (isset($item['field'])) {
                 $field_defns[] = $item['field'];
             } else if (isset($item['group'])) {
@@ -595,6 +609,8 @@ class JsonForm extends Form
             // Multiedits
             $valid = [];
             foreach ($tab_content as $item) {
+                $item = JsonForm::parseEntityField($item);
+
                 if (!isset($item['multiedit'])) continue;
 
                 $multed = $item['multiedit'];

--- a/src/sprout/Helpers/JsonForm.php
+++ b/src/sprout/Helpers/JsonForm.php
@@ -682,6 +682,13 @@ class JsonForm extends Form
 
         if (isset($field_defn['validate'])) {
             foreach ($field_defn['validate'] as $call) {
+                if ($call instanceof Entity) {
+                    $call = [
+                        'func' => $call->value,
+                        'args' => $call->attributes,
+                    ];
+                }
+
                 if (!isset($call['func'])) continue;
                 if (empty($call['args'])) $call['args'] = [];
 

--- a/src/sprout/Helpers/JsonForm.php
+++ b/src/sprout/Helpers/JsonForm.php
@@ -186,6 +186,11 @@ class JsonForm extends Form
         }
         $items = &$field['items'];
 
+        if (isset($items['func']) and $items['func'] instanceof Entity) {
+            $items['func'] = $items['func']->value;
+            $items['args'] = $items['func']->attributes;
+        }
+
         // Use a function to look up or generate items if specified
         if (isset($items['func']) and (count($items) == 1 or (count($items) == 2 and isset($items['args'])))) {
             if (strpos($items['func'], '::') !== false) {
@@ -365,6 +370,11 @@ class JsonForm extends Form
         $metadata = [
             'id' => $id,
         ];
+
+        if ($item['func'] instanceof Entity) {
+            $item['args'] = $item['func']->attributes;
+            $item['func'] = $item['func']->value;
+        }
 
         // Call a custom function and return the result
         if (strpos($item['func'], '::') !== false) {

--- a/src/sprout/Helpers/JsonForm.php
+++ b/src/sprout/Helpers/JsonForm.php
@@ -261,84 +261,128 @@ class JsonForm extends Form
      */
     public static function renderTabItem(array $item, $for, $id, array $data, array $errors, $name_prepend = '')
     {
+        if ($field = $item['field'] ?? null) {
+            return self::renderFieldItem($field, $for, $id, $data, $errors, $name_prepend);
+        }
+
+        if ($item['heading'] ?? null) {
+            return self::renderHeadingItem($item);
+        }
+
+        if ($item['html'] ?? null) {
+            return self::renderHtmlItem($item);
+        }
+
+        if ($group = $item['group'] ?? null) {
+            return self::renderGroupItem($group, $for, $id, $data, $errors, $name_prepend);
+        }
+
+        if ($item['func'] ?? null) {
+            return self::renderFuncItem($item, $id, $data, $errors);
+        }
+
+        if ($multed = $item['multiedit'] ?? null) {
+            return self::renderMultieditItem($multed, $for, $id, $data, $errors);
+        }
+
+        if ($auto = $item['autofill_list'] ?? null) {
+            return self::renderAutofillListItem($auto);
+        }
+
+        $type = key($item);
+        $type = is_numeric($type) ? 'unknown' : $type;
+
+        throw new InvalidArgumentException(
+            "Unknown item ({$type}); expected key 'field', 'heading', 'html', 'func', 'multiedit', or 'autofill_list'"
+        );
+    }
+
+
+    public static function renderFieldItem(array $field, $for, $id, array $data, array $errors, $name_prepend = '')
+    {
         // Metadata which is passed into argReplace for display/validator argument replacement
         $metadata = [
             'id' => $id,
         ];
 
-        if (isset($item['field'])) {
-            // Field
-            $field = $item['field'];
+        if (!isset($field['display']) or $field['display'] == null) return null;
+        if (isset($field['for'])) {
+            if (!in_array($for, $field['for'])) return null;
+        }
 
-            if (!isset($field['display']) or $field['display'] == null) return null;
-            if (isset($field['for'])) {
-                if (!in_array($for, $field['for'])) return null;
-            }
+        if (!array_key_exists($field['name'], $data) and !empty($field['default'])) {
+            Fb::setFieldValue($name_prepend . $field['name'], $field['default']);
 
-            if (!array_key_exists($field['name'], $data) and !empty($field['default'])) {
-                Fb::setFieldValue($name_prepend . $field['name'], $field['default']);
+            // For fields like Fb::checkboxBoolList(string $name, array $attrs, array $settings),
+            // $name_prepend doesn't actually get prepended. E.g. 'active' doesn't produce 'm_active' because
+            // the <input> name is set using the $settings param, not $name like most other field types
+            Fb::setFieldValue($field['name'], $field['default']);
+        }
 
-                // For fields like Fb::checkboxBoolList(string $name, array $attrs, array $settings),
-                // $name_prepend doesn't actually get prepended. E.g. 'active' doesn't produce 'm_active' because
-                // the <input> name is set using the $settings param, not $name like most other field types
-                Fb::setFieldValue($field['name'], $field['default']);
-            }
-
-            return JsonForm::renderField($field, $name_prepend, $metadata);
+        return self::renderField($field, $name_prepend, $metadata);
+    }
 
 
-        } elseif (isset($item['heading'])) {
-            // Heading
-            return '<h3>' . Enc::html($item['heading']) . '</h3>';
+    public static function renderHeadingItem(array $item)
+    {
+        return '<h3>' . Enc::html($item['heading']) . '</h3>';
+    }
 
 
-        } elseif (isset($item['html'])) {
-            // HTML text
-            return $item['html'];
+    public static function renderHtmlItem(array $item)
+    {
+        return $item['html'];
+    }
 
 
-        } elseif (isset($item['group'])) {
-            // Groups of similar items
-            $group = $item['group'];
+    public static function renderGroupItem(array $group, $for, $id, array $data, array $errors, $name_prepend = '')
+    {
+        if (empty($group['wrap-class'])) $group['wrap-class'] = '';
+        if (empty($group['item-class'])) $group['item-class'] = '';
 
-            if (empty($group['wrap-class'])) $group['wrap-class'] = '';
-            if (empty($group['item-class'])) $group['item-class'] = '';
+        $group['wrap-class'] = trim('field-group-wrap ' . $group['wrap-class']);
+        $group['item-class'] = trim('field-group-item ' . $group['item-class']);
 
-            $group['wrap-class'] = trim('field-group-wrap ' . $group['wrap-class']);
-            $group['item-class'] = trim('field-group-item ' . $group['item-class']);
-
-            $out = '<div class="' . $group['wrap-class'] . '">';
-            foreach ($group['items'] as $group_item) {
-                $out .= '<div class="' . $group['item-class'] . '">';
-                $out .= self::renderTabItem($group_item, $for, $id, $data, $errors, $name_prepend);
-                $out .= '</div>';
-            }
+        $out = '<div class="' . $group['wrap-class'] . '">';
+        foreach ($group['items'] as $group_item) {
+            $out .= '<div class="' . $group['item-class'] . '">';
+            $result = self::renderTabItem($group_item, $for, $id, $data, $errors, $name_prepend);
+            $out .= $result !== null ? (string) $result : '';
             $out .= '</div>';
-            return $out;
+        }
+        $out .= '</div>';
+        return $out;
+    }
 
 
-        } elseif (isset($item['func'])) {
-            // Call a custom function and return the result
-            if (strpos($item['func'], '::') !== false) {
-                list($class, $func) = explode('::', $item['func']);
-                $class = Sprout::nsClass($class, ['Sprout\Helpers']);
-                $func = $class . '::' . $func;
-            } else {
-                $func = $item['func'];
-            }
+    public static function renderFuncItem(array $item, $id, array $data, array $errors)
+    {
+        $metadata = [
+            'id' => $id,
+        ];
 
-            $args = [$id, $data, $errors];
-            if (isset($item['args'])) {
-                $args = array_merge($args, $item['args']);
-            }
-            $args = self::argReplace($args, $metadata);
+        // Call a custom function and return the result
+        if (strpos($item['func'], '::') !== false) {
+            list($class, $func) = explode('::', $item['func']);
+            $class = Sprout::nsClass($class, ['Sprout\Helpers']);
+            $func = $class . '::' . $func;
+        } else {
+            $func = $item['func'];
+        }
 
-            return call_user_func_array($func, $args);
+        $args = [$id, $data, $errors];
+        if (isset($item['args'])) {
+            $args = array_merge($args, $item['args']);
+        }
+        $args = self::argReplace($args, $metadata);
+
+        return call_user_func_array($func, $args);
+    }
 
 
-        } elseif (isset($item['multiedit'])) {
-            // Multiedit
-            $multed = $item['multiedit'];
+
+    public static function renderMultieditItem(array $multed, $for, $id, array $data, array $errors)
+    {
             if (!isset($data['multiedit_' . $multed['id']])) {
                 $data['multiedit_' . $multed['id']] = [];
             }
@@ -381,17 +425,13 @@ class JsonForm extends Form
             $out .= ob_get_clean();
 
             return $out;
-
-        } elseif (isset($item['autofill_list'])) {
-            // The autofillList method receives the whole object in $options straight from the JSON
-            $auto = $item['autofill_list'];
-            return Form::autofillList($auto['name'], [], $auto);
-
-        } else {
-            throw new InvalidArgumentException(
-                "Unknown item type; expected key 'field', 'heading', 'html', 'func', 'multiedit', or 'autofill_list'"
-            );
         }
+
+
+    public static function renderAutofillListItem(array $auto)
+    {
+        // The autofillList method receives the whole object in $options straight from the JSON
+        return Form::autofillList($auto['name'], [], $auto);
     }
 
 

--- a/src/sprout/Helpers/JsonForm.php
+++ b/src/sprout/Helpers/JsonForm.php
@@ -15,7 +15,7 @@ namespace Sprout\Helpers;
 
 use Exception;
 use InvalidArgumentException;
-
+use Nette\Neon\Entity;
 
 /**
  * Processes forms using configuration stored in a JSON file which specifies database columns, their HTML input fields,
@@ -251,7 +251,7 @@ class JsonForm extends Form
     /**
      * Render a tab item, which may be a field, heading, html block, etc
      *
-     * @param array $item The item definition
+     * @param array|Entity $item The item definition
      * @param string $for Either 'add', 'edit' or something custom; to check against the "for" parameter
      * @param int $id Record ID; for pass-through to function calls
      * @param array $data Data array; for pass-through to function calls
@@ -259,8 +259,13 @@ class JsonForm extends Form
      * @param string $name_prepend Prepended to the field name. Only applies for fields
      * @return string|null html
      */
-    public static function renderTabItem(array $item, $for, $id, array $data, array $errors, $name_prepend = '')
+    public static function renderTabItem(array|Entity $item, $for, $id, array $data, array $errors, $name_prepend = '')
     {
+        if ($item instanceof Entity) {
+            $type = Inflector::underscore(strtolower($item->value));
+            $item = [ $type => $item->attributes ];
+        }
+
         if ($field = $item['field'] ?? null) {
             return self::renderFieldItem($field, $for, $id, $data, $errors, $name_prepend);
         }


### PR DESCRIPTION
Something like this, hopefully easier on the eyes.
It certainly makes validity methods look real and much nicer to read.

```neon
Details:
    - Field(
        name: 'first_name'
        label: 'Given name'
        display: 'Fb::text'
        required: true
        validate: [ Validity::length(0, 100) ]
    )
    - Heading('')
    - Html('<p>I like peanuts</p>')
    - Group(
        Field(name: 'item1')
        Field(name: 'item2')
    )
  )
```