### PR TITLE
Add indexes on worker_jobs table to improve queue operations

### DIFF
--- a/src/sprout/db_struct.xml
+++ b/src/sprout/db_struct.xml
@@ -730,6 +730,12 @@
         <index>
             <col name="name" />
         </index>
+        <index>
+            <col name="date_added" />
+        </index>
+        <index>
+            <col name="status" />
+        </index>
     </table>
 
     <table name="ai_content_queue">


### PR DESCRIPTION
E.g. when collecting statistics or fetching new jobs to run

<img width="1311" height="573" alt="image" src="https://github.com/user-attachments/assets/7196dd91-048f-49e0-af09-e0a516b6129b" />
