### PR TITLE
Fix: CSV export broken in PHP 8.4

### DIFF
--- a/src/sprout/Helpers/QueryTo.php
+++ b/src/sprout/Helpers/QueryTo.php
@@ -104,7 +104,7 @@ class QueryTo
             }
         }
 
-        fputcsv($stream, $row);
+        fputcsv($stream, $row, escape: '');
 
         // Data
         foreach ($result as $row) {
@@ -121,7 +121,7 @@ class QueryTo
                 $out_row[] = $val;
             }
 
-            fputcsv($stream, $out_row);
+            fputcsv($stream, $out_row, escape: '');
         }
 
         if ($result instanceof PDOStatement) {


### PR DESCRIPTION
See note regarding escape param at:
https://www.php.net/manual/en/function.fputcsv.php