### PR TITLE
Make contents view itemlist easily modifiable

### DIFF
--- a/src/sprout/Controllers/Admin/ContentSubscriptionAdminController.php
+++ b/src/sprout/Controllers/Admin/ContentSubscriptionAdminController.php
@@ -60,6 +60,15 @@ class ContentSubscriptionAdminController extends ManagedAdminController
     public function _getNavigation() { return null; }
     public function _getVisibilityFields() { return []; }
 
+
+    /** @inheritDoc */
+    public function _contentsItemlistPreRender(Itemlist $itemlist): void
+    {
+        parent::_contentsItemlistPreRender($itemlist);
+        $itemlist->removeAction('edit');
+    }
+
+
     /**
     * Formats a resultset of items into an Itemlist
     *
@@ -72,30 +81,7 @@ class ContentSubscriptionAdminController extends ManagedAdminController
         $itemlist = new Itemlist();
         $itemlist->main_columns = $this->main_columns;
         $itemlist->items = $items;
-        $itemlist->setCheckboxes(true);
-        $itemlist->setOrdering(true);
-        $itemlist->setActionsClasses('button button-small');
-
-        // Add the actions
-        foreach ($this->main_actions as $name => $url) {
-            $itemlist->addAction($name, $url, 'button-grey');
-        }
-        if ($this->getDuplicateEnabled()) {
-            $itemlist->addAction('Duplicate', "SITE/admin/duplicate/{$this->controller_name}/%%", 'button-grey icon-before icon-add');
-        }
-        if ($this->main_delete) {
-            $itemlist->addAction('Delete', "SITE/admin/delete/{$this->controller_name}/%%", 'button button-red icon-before icon-delete');
-        }
-
-        // Add classes based on visibility fields
-        $visibility = $this->_getVisibilityFields();
-        $itemlist->setRowClassesFunc(function($row) use($visibility) {
-            $out = '';
-            foreach ($visibility as $name => $label) {
-                $out .= "main-list--{$name}-{$row[$name]} ";
-            }
-            return rtrim($out);
-        });
+        $this->_contentsItemlistPreRender($itemlist);
 
         // Prepare view which renders the main content area
         $outer = new PhpView("sprout/admin/generic_itemlist_outer");

--- a/src/sprout/Controllers/Admin/HasCategoriesAdminController.php
+++ b/src/sprout/Controllers/Admin/HasCategoriesAdminController.php
@@ -436,31 +436,7 @@ abstract class HasCategoriesAdminController extends ManagedAdminController {
         $itemlist = new Itemlist();
         $itemlist->main_columns = $this->main_columns;
         $itemlist->items = $items;
-        $itemlist->setCheckboxes(true);
-        $itemlist->setOrdering(true);
-        $itemlist->setActionsClasses('button button-small');
-
-        // Add the actions
-        $itemlist->addAction('edit', "SITE/admin/edit/{$this->controller_name}/%%");
-        foreach ($this->main_actions as $name => $url) {
-            $itemlist->addAction($name, $url, 'button-grey');
-        }
-        if ($this->getDuplicateEnabled()) {
-            $itemlist->addAction('Duplicate', "SITE/admin/duplicate/{$this->controller_name}/%%", 'button-grey icon-before icon-add');
-        }
-        if ($this->main_delete) {
-            $itemlist->addAction('Delete', "SITE/admin/delete/{$this->controller_name}/%%", 'button button-red icon-before icon-delete');
-        }
-
-        // Add classes based on visibility fields
-        $visibility = $this->_getVisibilityFields();
-        $itemlist->setRowClassesFunc(function($row) use($visibility) {
-            $out = '';
-            foreach ($visibility as $name => $label) {
-                $out .= "main-list--{$name}-{$row[$name]} ";
-            }
-            return rtrim($out);
-        });
+        $this->_contentsItemlistPreRender($itemlist);
 
         // Prepare view which renders the main content area
         $outer = new PhpView("sprout/admin/generic_itemlist_outer");

--- a/src/sprout/Controllers/Admin/ManagedAdminController.php
+++ b/src/sprout/Controllers/Admin/ManagedAdminController.php
@@ -1838,18 +1838,11 @@ abstract class ManagedAdminController extends Controller {
 
 
     /**
-     * Formats a resultset of items into an Itemlist
-     *
-     * @param Traversable $items The items to render.
-     * @param mixed $unused Not used in this controller, but used by has_categories
-     * @return string HTML
+     * Makes modifications to a list of items for the contents view before they are rendered.
+     * E.g. adding action buttons via {@see Itemlist::setActionsFunc()}
      */
-    public function _getContentsViewList($items, $unused)
+    public function _contentsItemlistPreRender(Itemlist $itemlist): void
     {
-        // Create the itemlist
-        $itemlist = new Itemlist();
-        $itemlist->main_columns = $this->main_columns;
-        $itemlist->items = $items;
         $itemlist->setCheckboxes(true);
         $itemlist->setOrdering(true);
         $itemlist->setActionsClasses('button button-small');
@@ -1875,6 +1868,23 @@ abstract class ManagedAdminController extends Controller {
             }
             return rtrim($out);
         });
+    }
+
+
+    /**
+     * Formats a resultset of items into an Itemlist
+     *
+     * @param Traversable $items The items to render.
+     * @param mixed $unused Not used in this controller, but used by has_categories
+     * @return string HTML
+     */
+    public function _getContentsViewList($items, $unused)
+    {
+        // Create the itemlist
+        $itemlist = new Itemlist();
+        $itemlist->main_columns = $this->main_columns;
+        $itemlist->items = $items;
+        $this->_contentsItemlistPreRender($itemlist);
 
         // Prepare view which renders the main content area
         $outer = new PhpView("sprout/admin/generic_itemlist_outer");

--- a/src/sprout/Helpers/Itemlist.php
+++ b/src/sprout/Helpers/Itemlist.php
@@ -333,6 +333,15 @@ class Itemlist
 
 
     /**
+     * Remove an action from this itemlist
+     */
+    public function removeAction(string $name): void
+    {
+        unset($this->actions[$name]);
+    }
+
+
+    /**
      * Set link classes common for all actions
      * The default is "actions--link".
      *


### PR DESCRIPTION
Currently if you want to modify the `Itemlist` for the contents view, you need to overload `_getContentsViewList()` by duplicating it, then adding some minor modifications (usually a call to `Itemlist::setActionsFunc()`).

This adds `_contentsItemlistPreRender` which lets you do minor modifications by calling the parent method first, or doing something completely different by skipping the parent call. `ContentSubscriptionAdminController` provides a good example, because its only difference was not adding the `edit` action (now it lets the parent add it, then removes it immediately after, hence the new `Itemlist::removeAction()` method)