### PR TITLE
Support PHP 8.1 BackedEnums by default in Itemlist

### DIFF
--- a/src/sprout/Helpers/Itemlist.php
+++ b/src/sprout/Helpers/Itemlist.php
@@ -15,6 +15,7 @@ namespace Sprout\Helpers;
 
 use InvalidArgumentException;
 use PDOStatement;
+use BackedEnum;
 use Closure;
 
 
@@ -498,7 +499,11 @@ class Itemlist
             return Text::limitedSubsetHtml($defn($item_data));
 
         } else {
-            return Enc::html($item_data[$defn]);
+            $value = $item_data[$defn];
+            if ($value instanceof BackedEnum) {
+                $value = $value->value;
+            }
+            return Enc::html($value);
         }
     }
 


### PR DESCRIPTION
E.g.

```php
enum Foods: string {
    case Apple = 'Apple';
    case Banana = 'Banana';
}

$list = new Itemlist();
$list->items = [
    ['food' => Foods::Apple, 'variety' => 'Granny smith'],
    ['food' => Foods::Apple, 'variety' => 'Fuji'],
    ['food' => Foods::Banana, 'variety' => 'Cavendish'],
    ['food' => Foods::Banana, 'variety' => 'Lady finger'],
];
$list->main_columns = ['Food' => 'food', 'Variety' => 'variety'];
```

Before:

<img width="1323" height="284" alt="Screenshot 2026-06-02 at 17-02-35 Dummy SproutCMS" src="https://github.com/user-attachments/assets/fef4e0cc-cfbd-4e1c-b7ac-522a482fb8a5" />

After:

<img width="1314" height="270" alt="Screenshot 2026-06-02 at 17-04-35 Dummy SproutCMS" src="https://github.com/user-attachments/assets/28baabcc-9249-4d38-809a-ae871763a90a" />
