### PR TITLE
Increase size of columns in exception log table

### DIFF
--- a/src/sprout/core/Kohana.php
+++ b/src/sprout/core/Kohana.php
@@ -967,9 +967,9 @@ final class Kohana {
         $pdb->execute($insert, [
             'date' => $pdb->now(),
             'class' => get_class($exception),
-            'message' => substr($exception->getMessage(), 0, 500),
-            'exception' => substr(json_encode($secrets->mask($ex_data)), 0, 65000),
-            'trace' => substr(json_encode($trace), 0, 65000),
+            'message' => substr($exception->getMessage(), 0, 1000),
+            'exception' => substr(json_encode($secrets->mask($ex_data)), 0, 1_000_000),
+            'trace' => substr(json_encode($trace), 0, 200_000),
             'server' => substr(json_encode($secrets->mask($_SERVER)), 0, 65000),
             'get' => substr(json_encode($secrets->mask($_GET)), 0, 65000),
             'session' => substr(json_encode($secrets->mask($_SESSION)), 0, 65000),

--- a/src/sprout/db_struct.xml
+++ b/src/sprout/db_struct.xml
@@ -1095,7 +1095,7 @@
         <column name="id" type="INT UNSIGNED" allownull="0" autoinc="1" />
         <column name="date_generated" type="DATETIME" allownull="0" />
         <column name="class_name" type="VARCHAR(200)" allownull="0" />
-        <column name="message" type="VARCHAR(500)" allownull="0" />
+        <column name="message" type="VARCHAR(1000)" allownull="0" />
         <column name="caught" type="TINYINT UNSIGNED" allownull="0" default="0" />
 
         <!-- Stored as bin2hex(inet_pton($ip)) -->
@@ -1108,8 +1108,8 @@
             <val>js</val>
         </column>
 
-        <column name="exception_object" type="TEXT" allownull="0" />
-        <column name="exception_trace" type="TEXT" allownull="0" />
+        <column name="exception_object" type="MEDIUMTEXT" allownull="0" />
+        <column name="exception_trace" type="MEDIUMTEXT" allownull="0" />
 
         <column name="server" type="TEXT" allownull="0" />
         <column name="get_data" type="TEXT" allownull="0" />

--- a/src/sprout/views/dbtools/exception_details.php
+++ b/src/sprout/views/dbtools/exception_details.php
@@ -70,7 +70,15 @@ pre {
     <pre><?php echo Enc::html($log['message']); ?></pre>
 
     <h3>Exception object</h3>
-    <pre><?php echo Enc::html(print_r(json_decode($log['exception_object'], true), true)); ?></pre>
+    <?php
+    $ex_data = json_decode($log['exception_object'], true);
+    if ($ex_data === null) {
+        echo "<div class='message-bar-warning'>JSON decoding failed</div>\n";
+        echo '<pre>', Enc::html($log['exception_object']), '</pre>';
+    } else {
+        echo '<pre>', Enc::html(print_r($ex_data, true)), '</pre>';
+    }
+    ?>
 
     <h3>Exception trace</h3>
     <pre><?php echo Enc::html($log->renderTrace()); ?></pre>


### PR DESCRIPTION
Sometimes you just need that extra push over the cliff. These go to eleven.