### PR TITLE
Fix: content replacement regex exhaustion can break page rendering

### DIFF
--- a/src/sprout/Helpers/ContentReplace.php
+++ b/src/sprout/Helpers/ContentReplace.php
@@ -16,6 +16,7 @@ namespace Sprout\Helpers;
 use DOMDocument;
 
 use karmabunny\pdb\Exceptions\RowMissingException;
+use Kohana;
 
 
 /**
@@ -68,7 +69,25 @@ class ContentReplace
      */
     public static function intlinks($text)
     {
-        return preg_replace_callback('!<a ([^>]*?)href="page/view_by_id/([0-9]+)"!', array(__CLASS__, '_intlinks'), $text);
+        $res = preg_replace_callback(
+            '!<a ([^>]{0,10000})href="page/view_by_id/([0-9]+)"!',
+            static::_intlinks(...),
+            $text
+        );
+
+        if ($res === null) {
+            $err_msg = "ContentReplace::intlinks failed - preg_replace_callback returned null";
+            $ex = new class($err_msg) extends \Exception {
+                public int $text_len;
+                public string $text;
+            };
+            $ex->text_len = strlen($text);
+            $ex->text = $text;
+            Kohana::logException($ex);
+            return $text;
+        }
+
+        return $res;
     }
 
     private static function _intlinks($matches)

--- a/src/sprout/Helpers/Sprout.php
+++ b/src/sprout/Helpers/Sprout.php
@@ -726,8 +726,8 @@ class Sprout
         //  - some letters (a-z)
         // and the A must only have non HTML content (doesn't contain < or >)
         //
-        return preg_replace_callback(
-            '!<a[^>]+href="([^"]*)files/([^"]+\.([a-z]+))"[^>]*>([^<>]+)</a>!',
+        $res = preg_replace_callback(
+            '!<a[^>]{1,10000}href="([^"]{0,1000})files/([^"]+\.([a-z]+))"[^>]*>([^<>]+)</a>!',
 
             function($matches) {
                 $matches[1] = html_entity_decode($matches[1]);
@@ -776,6 +776,20 @@ class Sprout
 
             $html
         );
+
+        if ($res === null) {
+            $err_msg = "Sprout::specialFileLinks failed - preg_replace_callback returned null";
+            $ex = new class($err_msg) extends \Exception {
+                public int $html_len;
+                public string $html;
+            };
+            $ex->html_len = strlen($html);
+            $ex->html = $html;
+            Kohana::logException($ex);
+            return $html;
+        }
+
+        return $res;
     }
 
 


### PR DESCRIPTION
E.g. `<a class="js-popup-image" href="data:image/jpeg;base64,mega/long/data">Please render</a>`