### PR TITLE
Add PHPStan docblock types for model queries

### DIFF
--- a/src/sprout/Helpers/Model.php
+++ b/src/sprout/Helpers/Model.php
@@ -42,8 +42,9 @@ abstract class Model extends Record implements Validates
      */
     public static function find(array $conditions = []): ModelQuery
     {
-        return (new ModelQuery(static::class))
-            ->where($conditions);
+        /** @var ModelQuery<static> $mq */
+        $mq = new ModelQuery(static::class);
+        return $mq->where($conditions);
     }
 
 

--- a/src/sprout/Helpers/Model.php
+++ b/src/sprout/Helpers/Model.php
@@ -38,7 +38,7 @@ abstract class Model extends Record implements Validates
     /**
      * @inheritdoc
      * @param array $conditions
-     * @return ModelQuery
+     * @return ModelQuery<static>
      */
     public static function find(array $conditions = []): ModelQuery
     {

--- a/src/sprout/Helpers/ModelQuery.php
+++ b/src/sprout/Helpers/ModelQuery.php
@@ -21,6 +21,11 @@ use karmabunny\pdb\PdbQuery;
  * Base model query
  *
  * @package Sprout\Helpers
+ *
+ * @template T of Model
+ *
+ * @method ($throw is true ? T : ($throw is null ? T : ?T)) one(?bool $throw = null)
+ * @method T[] all()
  */
 class ModelQuery extends PdbModelQuery
 {


### PR DESCRIPTION
I.e. results can be relied upon:
SomeModel::find($clauses)->all(); // SomeModel[]
SomeModel::find($clauses)->one(); // SomeModel
SomeModel::find($clauses)->one(false); // ?SomeModel