### PR TITLE
Feat/request headers

### DIFF
--- a/src/sprout/Controllers/DbToolsController.php
+++ b/src/sprout/Controllers/DbToolsController.php
@@ -281,6 +281,7 @@ class DbToolsController extends Controller
             'Request::userIp' => Request::userIp(),
             'Request::method' => Request::method(),
             'Request::isAjax' => (Request::isAjax() ? 'true' : 'false'),
+            'Request::isLoadBalanced' => (Request::isLoadBalanced() ? 'true' : 'false'),
             'Request::protocol' => Request::protocol(),
             'PHP date' => date('Y-m-d H:i:s'),
             'PHP TZ' => date_default_timezone_get(),

--- a/src/sprout/Helpers/Recaptcha3.php
+++ b/src/sprout/Helpers/Recaptcha3.php
@@ -68,7 +68,7 @@ class Recaptcha3
         $data = [];
         $data['secret'] = $key;
         $data['response'] = $_POST['g-recaptcha-response'];
-        $data['remoteip'] = $_SERVER['REMOTE_ADDR'];
+        $data['remoteip'] = Request::userIp();
 
         // Post request
         $response = HttpReq::req(

--- a/src/sprout/Helpers/Request.php
+++ b/src/sprout/Helpers/Request.php
@@ -188,7 +188,7 @@ class Request
         if ($config and is_array($config)) {
             // Use the immediate connecting IP.
             $addr = trim($_SERVER['REMOTE_ADDR'] ?? '');
-            $addr = filter_var($addr, FILTER_VALIDATE_IP);
+            $addr = filter_var($addr, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4);
 
             if (!$addr) {
                 return false;

--- a/src/sprout/Helpers/Request.php
+++ b/src/sprout/Helpers/Request.php
@@ -104,7 +104,7 @@ class Request
             return NULL;
         }
 
-        if (Kohana::config('sprout.load_balanced')) {
+        if (self::isLoadBalanced()) {
             // https://developers.cloudflare.com/fundamentals/reference/http-headers/#cf-visitor
             if (
                 is_array($visitor = json_decode($_SERVER['HTTP_CF_VISITOR'] ?? '', true))
@@ -166,6 +166,43 @@ class Request
 
 
     /**
+     * Is this request coming from a load balancer?
+     *
+     * Whether to trust forwarded headers for `userIp()` and `protocol()`.
+     *
+     * The `sprout.load_balanced` config can be:
+     * - array: a list of IP addresses or CIDR ranges to trust
+     * - true: always trust forwarded headers
+     * - false: never trust forwarded headers
+     *
+     * @return bool
+     */
+    public static function isLoadBalanced(): bool
+    {
+        $config = Kohana::config('sprout.load_balanced');
+
+        if ($config === true) {
+            return true;
+        }
+
+        if ($config and is_array($config)) {
+            // Use the immediate connecting IP.
+            $addr = trim($_SERVER['REMOTE_ADDR'] ?? '');
+            $addr = filter_var($addr, FILTER_VALIDATE_IP);
+
+            if (!$addr) {
+                return false;
+            }
+
+            // TODO this only supports ipv4.
+            return Sprout::ipaddressInArray($addr, $config);
+        }
+
+        return false;
+    }
+
+
+    /**
      * Returns current request method.
      *
      * @throws  Kohana_Exception in case of an unknown request method
@@ -191,7 +228,7 @@ class Request
      */
     public static function userIp()
     {
-        if (Kohana::config('sprout.load_balanced')) {
+        if (self::isLoadBalanced()) {
             // https://developers.cloudflare.com/fundamentals/reference/http-headers/#cf-connecting-ip
             if ($addr = trim($_SERVER['HTTP_CF_CONNECTING_IP'] ?? '')) {
                 $addr = filter_var($addr, FILTER_VALIDATE_IP);

--- a/src/sprout/Helpers/Request.php
+++ b/src/sprout/Helpers/Request.php
@@ -131,6 +131,10 @@ class Request
             }
         }
 
+        if (isset($_SERVER['REQUEST_SCHEME'])) {
+            return strtolower($_SERVER['REQUEST_SCHEME']);
+        }
+
         if (trim($_SERVER['HTTPS'] ?? '') === 'on') {
             return 'https';
         }

--- a/src/sprout/Helpers/Router.php
+++ b/src/sprout/Helpers/Router.php
@@ -187,6 +187,10 @@ class Router
             // Remove the URI from $_SERVER['QUERY_STRING']
             $_SERVER['QUERY_STRING'] = preg_replace('~\bkohana_uri\b[^&]*+&?~', '', $_SERVER['QUERY_STRING']);
         }
+        elseif (isset($_SERVER['REQUEST_URI']))
+        {
+            Router::$current_uri = $_SERVER['REQUEST_URI'];
+        }
         elseif (isset($_SERVER['PATH_INFO']) AND $_SERVER['PATH_INFO'])
         {
             Router::$current_uri = $_SERVER['PATH_INFO'];

--- a/src/sprout/Helpers/Router.php
+++ b/src/sprout/Helpers/Router.php
@@ -189,7 +189,7 @@ class Router
         }
         elseif (isset($_SERVER['REQUEST_URI']))
         {
-            Router::$current_uri = $_SERVER['REQUEST_URI'];
+            Router::$current_uri = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
         }
         elseif (isset($_SERVER['PATH_INFO']) AND $_SERVER['PATH_INFO'])
         {

--- a/src/sprout/Helpers/Url.php
+++ b/src/sprout/Helpers/Url.php
@@ -165,7 +165,7 @@ class Url
      * Sends a page redirect header and runs the system.redirect Event.
      *
      * @param  string|string[] $uri site URI or URL to redirect to, or array of strings if method is 300
-     * @param  string $method HTTP method of redirect
+     * @param  string|int $method HTTP method of redirect
      * @return never
      * @throws LogicException
      */

--- a/src/sprout/config/config.php
+++ b/src/sprout/config/config.php
@@ -71,6 +71,11 @@ if (PHP_SAPI === 'cgi') {
 }
 
 /**
+ * Redirect if KOHANA is found in the request_uri.
+ */
+$config['hide_index'] = false;
+
+/**
  * Fake file extension that will be added to all generated URLs. Example: .html
  */
 $config['url_suffix'] = '';

--- a/src/sprout/core/Bootstrap.php
+++ b/src/sprout/core/Bootstrap.php
@@ -69,7 +69,7 @@ Router::originCleanup();
 
 if (
     Kohana::config('core.hide_index')
-    and str_starts_with($_SERVER['REQUEST_URI'], '/' . KOHANA)
+    and str_starts_with($_SERVER['REQUEST_URI'] ?? '', '/' . KOHANA)
 ) {
     Url::redirect(Router::$complete_uri, 301);
 }

--- a/src/sprout/core/Bootstrap.php
+++ b/src/sprout/core/Bootstrap.php
@@ -71,7 +71,7 @@ if (
     Kohana::config('core.hide_index')
     and str_starts_with($_SERVER['REQUEST_URI'], '/' . KOHANA)
 ) {
-    Url::redirect(Router::$current_uri, 301);
+    Url::redirect(Router::$complete_uri, 301);
 }
 
 Register::services(CoreAdminAuth::class);

--- a/src/sprout/core/Bootstrap.php
+++ b/src/sprout/core/Bootstrap.php
@@ -67,6 +67,13 @@ Router::findUri();
 // Redirect to alternate hostname and/or protocol if requred
 Router::originCleanup();
 
+if (
+    Kohana::config('core.hide_index')
+    and str_starts_with($_SERVER['REQUEST_URI'], '/' . KOHANA)
+) {
+    Url::redirect(Router::$current_uri, 301);
+}
+
 Register::services(CoreAdminAuth::class);
 
 // Mini verion of framework when using the welcome system


### PR DESCRIPTION
Grab-bag of improvements and fixes when parsing incoming requests.

- `REQUEST_URI` means nginx/apache doesn't need to append `kohana_uri` to rewrites
- `isLoadBalanced()` provides more safety when trusting incoming headers
- we can automatically clean out `index.php` from URLs, which is important for some people