### PR TITLE
Feat/dbtools exception log improvements

### DIFF
--- a/src/sprout/Controllers/DbToolsController.php
+++ b/src/sprout/Controllers/DbToolsController.php
@@ -2915,8 +2915,8 @@ class DbToolsController extends Controller
         $view->server = $server;
         $uri = $server['REQUEST_URI'] ?? '';
         if ($uri) {
-            if (!empty($server['SERVER_NAME'])) {
-                $uri = $server['SERVER_NAME'] . $uri;
+            if (!empty($server['HTTP_HOST'])) {
+                $uri = $server['HTTP_HOST'] . $uri;
                 if (!empty($server['REQUEST_SCHEME'])) {
                     $uri = $server['REQUEST_SCHEME'] . '://' . $uri;
                 }

--- a/src/sprout/Controllers/DbToolsController.php
+++ b/src/sprout/Controllers/DbToolsController.php
@@ -2913,7 +2913,19 @@ class DbToolsController extends Controller
         $server = json_decode($log['server'] ?? '[]', true);
         $view = new PhpView('sprout/dbtools/exception_details');
         $view->server = $server;
-        $view->uri = $server['REQUEST_URI'] ?? '';
+        $uri = $server['REQUEST_URI'] ?? '';
+        if ($uri) {
+            if (!empty($server['SERVER_NAME'])) {
+                $uri = $server['SERVER_NAME'] . $uri;
+                if (!empty($server['REQUEST_SCHEME'])) {
+                    $uri = $server['REQUEST_SCHEME'] . '://' . $uri;
+                }
+            }
+            if (!empty($server['REQUEST_METHOD'])) {
+                $uri = $server['REQUEST_METHOD'] . ' ' . $uri;
+            }
+        }
+        $view->uri = $uri;
         $view->referer = $server['HTTP_REFERER'] ?? '';
         $view->log = $log;
 

--- a/src/sprout/Controllers/DbToolsController.php
+++ b/src/sprout/Controllers/DbToolsController.php
@@ -2910,7 +2910,7 @@ class DbToolsController extends Controller
         }
 
         // View
-        $server = json_decode($log['server'], true);
+        $server = json_decode($log['server'] ?? '[]', true);
         $view = new PhpView('sprout/dbtools/exception_details');
         $view->server = $server;
         $view->uri = $server['REQUEST_URI'] ?? '';


### PR DESCRIPTION
- fix: exception log record view breaks when entry doesn't exist
- include full URL and HTTP request method in exception log record view

Now looks like this:

<img width="681" height="196" alt="image" src="https://github.com/user-attachments/assets/bf903363-c579-4425-842d-32a67def08db" />