### PR TITLE
Properly apply generic types for ModelQuery

### DIFF
--- a/src/sprout/Helpers/Model.php
+++ b/src/sprout/Helpers/Model.php
@@ -42,9 +42,8 @@ abstract class Model extends Record implements Validates
      */
     public static function find(array $conditions = []): ModelQuery
     {
-        /** @var ModelQuery<static> $mq */
-        $mq = new ModelQuery(static::class);
-        return $mq->where($conditions);
+        return (new ModelQuery(static::class))
+            ->where($conditions);
     }
 
 

--- a/src/sprout/Helpers/ModelQuery.php
+++ b/src/sprout/Helpers/ModelQuery.php
@@ -23,6 +23,7 @@ use karmabunny\pdb\PdbQuery;
  * @package Sprout\Helpers
  *
  * @template T of Model
+ * @extends PdbModelQuery<T>
  *
  * @method ($throw is true ? T : ($throw is null ? T : ?T)) one(?bool $throw = null)
  * @method T[] all()
@@ -46,7 +47,7 @@ class ModelQuery extends PdbModelQuery
     /**
      *
      * @param string|int|null $id
-     * @return self
+     * @return $this
      */
     public function id($id)
     {
@@ -57,7 +58,7 @@ class ModelQuery extends PdbModelQuery
     /**
      *
      * @param string|null $uid
-     * @return self
+     * @return $this
      */
     public function uid($uid)
     {
@@ -69,7 +70,7 @@ class ModelQuery extends PdbModelQuery
     /**
      *
      * @param null|int|float|string|DateTimeInterface $date
-     * @return self
+     * @return $this
      */
     public function addedAfter($date)
     {
@@ -81,7 +82,7 @@ class ModelQuery extends PdbModelQuery
     /**
      *
      * @param null|int|float|string|DateTimeInterface $date
-     * @return self
+     * @return $this
      */
     public function addedBefore($date)
     {
@@ -94,7 +95,7 @@ class ModelQuery extends PdbModelQuery
      *
      * @param null|int|float|string|DateTimeInterface $after
      * @param null|int|float|string|DateTimeInterface $before
-     * @return self
+     * @return $this
      */
     public function addedBetween($after, $before)
     {
@@ -106,7 +107,7 @@ class ModelQuery extends PdbModelQuery
     /**
      *
      * @param null|int|float|string|DateTimeInterface $date
-     * @return self
+     * @return $this
      */
     public function modifiedAfter($date)
     {
@@ -118,7 +119,7 @@ class ModelQuery extends PdbModelQuery
     /**
      *
      * @param null|int|float|string|DateTimeInterface $date
-     * @return self
+     * @return $this
      */
     public function modifiedBefore($date)
     {
@@ -131,7 +132,7 @@ class ModelQuery extends PdbModelQuery
      *
      * @param null|int|float|string|DateTimeInterface $after
      * @param null|int|float|string|DateTimeInterface $before
-     * @return self
+     * @return $this
      */
     public function modifiedBetween($after, $before)
     {


### PR DESCRIPTION
And revert explicit type declaration in Model::find as it's no longer necessary