### PR TITLE
Feat/session drivers

### DIFF
--- a/src/sprout/Helpers/Drivers/Session/Cache.php
+++ b/src/sprout/Helpers/Drivers/Session/Cache.php
@@ -54,7 +54,7 @@ class Cache implements SessionDriver
         Kohana::log('debug', 'Session Cache Driver Initialized');
     }
 
-    public function open($path, $name)
+    public function open(string $path, string $name): bool
     {
         $config = Kohana::config('session.storage');
 
@@ -77,12 +77,12 @@ class Cache implements SessionDriver
         return true;
     }
 
-    public function close()
+    public function close(): bool
     {
         return TRUE;
     }
 
-    public function read($id)
+    public function read(string $id): string
     {
         $id = 'session_'.$id;
         if ($data = $this->cache->get($id))
@@ -94,7 +94,7 @@ class Cache implements SessionDriver
         return '';
     }
 
-    public function write($id, $data)
+    public function write(string $id, string $data): bool
     {
         $id = 'session_'.$id;
         $data = Kohana::config('session.encryption') ? $this->encrypt->encode($data) : $data;
@@ -102,24 +102,24 @@ class Cache implements SessionDriver
         return $this->cache->set($id, $data);
     }
 
-    public function destroy($id)
+    public function destroy(string $id): bool
     {
         $id = 'session_'.$id;
         return $this->cache->delete($id);
     }
 
-    public function regenerate()
+    public function regenerate(): string
     {
         session_regenerate_id(TRUE);
 
         // Return new session id
-        return session_id();
+        return session_id() ?: '';
     }
 
-    public function gc($maxlifetime)
+    public function gc(int $maxlifetime): int|false
     {
         // Just return, caches are automatically cleaned up
-        return TRUE;
+        return 0;
     }
 
 } // End Session Cache Driver

--- a/src/sprout/Helpers/Drivers/Session/Database.php
+++ b/src/sprout/Helpers/Drivers/Session/Database.php
@@ -68,17 +68,17 @@ class Database implements SessionDriver
         Kohana::log('debug', 'Session Database Driver Initialized');
     }
 
-    public function open($path, $name)
+    public function open(string $path, string $name): bool
     {
         return TRUE;
     }
 
-    public function close()
+    public function close(): bool
     {
         return TRUE;
     }
 
-    public function read($id)
+    public function read(string $id): string
     {
         // Load the session
         try {
@@ -97,7 +97,7 @@ class Database implements SessionDriver
         return ($this->encrypt === NULL) ? base64_decode($data) : $this->encrypt->decode($data);
     }
 
-    public function write($id, $data)
+    public function write(string $id, string $data): bool
     {
         $data = array
         (
@@ -131,7 +131,7 @@ class Database implements SessionDriver
         return (bool) $count;
     }
 
-    public function destroy($id)
+    public function destroy(string $id): bool
     {
         // Delete the requested session
         $this->pdb->delete($this->table, array('session_id' => $id));
@@ -142,20 +142,20 @@ class Database implements SessionDriver
         return TRUE;
     }
 
-    public function regenerate()
+    public function regenerate(): string
     {
         // Generate a new session id
         session_regenerate_id();
 
         // Return new session id
-        return session_id();
+        return session_id() ?: '';
     }
 
-    public function gc($maxlifetime)
+    public function gc(int $maxlifetime): int|false
     {
         // Delete all expired sessions
-        $this->pdb->delete($this->table, [['last_activity', '<', time() - $maxlifetime]]);
-        return true;
+        $count = $this->pdb->delete($this->table, [['last_activity', '<', time() - $maxlifetime]]);
+        return $count;
     }
 
 } // End Session Database Driver

--- a/src/sprout/Helpers/Drivers/Session/Redis.php
+++ b/src/sprout/Helpers/Drivers/Session/Redis.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Copyright (C) 2017 Karmabunny Pty Ltd.
+ *
+ * This file is a part of SproutCMS.
+ *
+ * SproutCMS is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU General Public License as published by the Free Software Foundation, either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * For more information, visit <http://getsproutcms.com>.
+ */
+namespace Sprout\Helpers\Drivers\Session;
+
+use Kohana;
+
+use karmabunny\rdb\RdbSessionHandler;
+use Sprout\Helpers\Rdb;
+
+/**
+ * Session Redis driver.
+ */
+class Redis extends RdbSessionHandler
+{
+
+    public function __construct()
+    {
+        $rdb = Rdb::getInstance();
+
+        $config = Kohana::config('session');
+        $config['prefix'] ??= 'session:';
+
+        parent::__construct($rdb, $config);
+    }
+}

--- a/src/sprout/Helpers/Drivers/SessionDriver.php
+++ b/src/sprout/Helpers/Drivers/SessionDriver.php
@@ -15,52 +15,15 @@
  */
 namespace Sprout\Helpers\Drivers;
 
+use SessionHandlerInterface;
 
 /**
  * Session driver interface
+ *
+ * @deprecated Use SessionHandlerInterface instead
  */
-interface SessionDriver {
-
-    /**
-     * Opens a session.
-     *
-     * @param   string $path Save path
-     * @param   string $name Session name
-     * @return  bool
-     */
-    public function open($path, $name);
-
-    /**
-     * Closes a session.
-     *
-     * @return  bool
-     */
-    public function close();
-
-    /**
-     * Reads a session.
-     *
-     * @param   string $id Session id
-     * @return  string
-     */
-    public function read($id);
-
-    /**
-     * Writes a session.
-     *
-     * @param   string $id Session id
-     * @param   string $data Session data
-     * @return  bool
-     */
-    public function write($id, $data);
-
-    /**
-     * Destroys a session.
-     *
-     * @param   string $id Session id
-     * @return  bool
-     */
-    public function destroy($id);
+interface SessionDriver extends SessionHandlerInterface
+{
 
     /**
      * Regenerates the session id.
@@ -69,12 +32,4 @@ interface SessionDriver {
      */
     public function regenerate();
 
-    /**
-     * Garbage collection.
-     *
-     * @param   int|string $maxlifetime Session expiration period
-     * @return  bool
-     */
-    public function gc($maxlifetime);
-
-} // End Session Driver Interface
+}

--- a/src/sprout/Helpers/Session.php
+++ b/src/sprout/Helpers/Session.php
@@ -124,7 +124,7 @@ class Session
             ini_set('session.gc_maxlifetime', (Session::$config['expiration'] == 0) ? 86400 : Session::$config['expiration']);
         }
 
-        if (Session::$config['driver'] !== 'native' and Session::$config['driver'] !== 'redis') {
+        if (Session::$config['driver'] !== 'native') {
             // Set driver name
             $driver = 'Sprout\\Helpers\\Drivers\\Session\\' . ucfirst(Session::$config['driver']);
 
@@ -158,11 +158,6 @@ class Session
             Kohana::config('cookie.secure'),
             true    // never allow javascript to access session cookies
         );
-
-        // If redis is available then it's used for session storage
-        if (self::$config['driver'] == 'redis') {
-            Rdb::registerSessionHandler();
-        }
 
         // Start the session!
         session_start();

--- a/src/sprout/Helpers/Session.php
+++ b/src/sprout/Helpers/Session.php
@@ -18,6 +18,7 @@ namespace Sprout\Helpers;
 use Kohana;
 use Kohana_Exception;
 use karmabunny\kb\Events;
+use SessionHandlerInterface;
 use Sprout\Events\ShutdownEvent;
 use Sprout\Helpers\Drivers\SessionDriver;
 
@@ -135,19 +136,10 @@ class Session
             Session::$driver = new $driver();
 
             // Validate the driver
-            if ( ! (Session::$driver instanceof SessionDriver))
-                throw new Kohana_Exception('core.driver_implements', Session::$config['driver'], static::class, 'SessionDriver');
+            if ( ! (Session::$driver instanceof SessionHandlerInterface))
+                throw new Kohana_Exception('core.driver_implements', Session::$config['driver'], static::class, 'SessionHandlerInterface');
 
-            // Register non-native driver as the session handler
-            session_set_save_handler
-            (
-                array(Session::$driver, 'open'),
-                array(Session::$driver, 'close'),
-                array(Session::$driver, 'read'),
-                array(Session::$driver, 'write'),
-                array(Session::$driver, 'destroy'),
-                array(Session::$driver, 'gc')
-            );
+            session_set_save_handler(Session::$driver, false);
         }
 
         // Validate the session name
@@ -246,7 +238,12 @@ class Session
      */
     public static function regenerate()
     {
-        if (Session::$config['driver'] === 'native' or Session::$config['driver'] == 'redis')
+        if (Session::$driver instanceof SessionDriver)
+        {
+            // Pass the regenerating off to the driver in case it wants to do anything special
+            $_SESSION['session_id'] = Session::$driver->regenerate();
+        }
+        else
         {
             // Generate a new session id
             // Note: also sets a new session cookie with the updated id
@@ -254,11 +251,6 @@ class Session
 
             // Update session with new id
             $_SESSION['session_id'] = session_id();
-        }
-        else
-        {
-            // Pass the regenerating off to the driver in case it wants to do anything special
-            $_SESSION['session_id'] = Session::$driver->regenerate();
         }
 
         // Get the session name


### PR DESCRIPTION
Enough lollygagging. This is native support for `SessionHandlerInterface`.

This removes the special handling we already had for the redis driver and brings it inline with the rest.

_At some point_ all of these driver patterns (archive, cache, image, session) will be configurable so that we can register custom drivers downstream. Not today - but this is an important first step.

Currently untested.