### PR TITLE
Feat/controller response

### DIFF
--- a/src/sprout/Controllers/BaseController.php
+++ b/src/sprout/Controllers/BaseController.php
@@ -102,8 +102,9 @@ abstract class BaseController
         }
 
         if (!isset($this->response)) {
+            $status = http_response_code() ?: 200;
             $headers = Sprout::getHeaders();
-            $this->response = new Response(200, $headers);
+            $this->response = new Response($status, $headers);
         }
     }
 

--- a/src/sprout/Controllers/BaseController.php
+++ b/src/sprout/Controllers/BaseController.php
@@ -23,6 +23,7 @@ use Kohana;
 use Nyholm\Psr7\Response;
 use Nyholm\Psr7\Stream;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamInterface;
 use ReflectionException;
 use ReflectionMethod;
@@ -35,6 +36,7 @@ use Sprout\Events\RedirectEvent;
 use Sprout\Helpers\BaseView;
 use Sprout\Helpers\Html;
 use Sprout\Helpers\Json;
+use Sprout\Helpers\Request;
 use Sprout\Helpers\Sprout;
 use Sprout\Helpers\Url;
 
@@ -50,6 +52,14 @@ abstract class BaseController
 
     // Allow all controllers to run in production by default
     const ALLOW_PRODUCTION = TRUE;
+
+
+    /**
+     * A request object to read from the client.
+     *
+     * @var ServerRequestInterface
+     */
+    public ServerRequestInterface $request;
 
 
     /**
@@ -73,6 +83,8 @@ abstract class BaseController
             // Set the instance to the first controller loaded
             Kohana::$instance = $this;
         }
+
+        $this->request = Request::getPsrRequest();
 
         $headers = Sprout::getHeaders();
         $this->response = new Response(200, $headers);

--- a/src/sprout/Controllers/BaseController.php
+++ b/src/sprout/Controllers/BaseController.php
@@ -319,12 +319,14 @@ abstract class BaseController
         $headers = $this->response->getHeaders();
 
         if ($method === 'refresh') {
+            $status = 200;
             $headers['Refresh'] = [0, "url={$uri}"];
         } else {
+            $status = (int) $method;
             $headers['Location'] = [$uri];
         }
 
-        $this->response = new Response($method, $headers, $body);
+        $this->response = new Response($status, $headers, $body);
         return $this->response;
     }
 

--- a/src/sprout/Controllers/BaseController.php
+++ b/src/sprout/Controllers/BaseController.php
@@ -78,16 +78,33 @@ abstract class BaseController
      */
     public function __construct()
     {
+        $this->init();
+    }
+
+
+    /**
+     * Initialise the controller.
+     *
+     * This is called on construct AND run().
+     *
+     * @return void
+     */
+    public function init(): void
+    {
         if (Kohana::$instance == NULL)
         {
             // Set the instance to the first controller loaded
             Kohana::$instance = $this;
         }
 
-        $this->request = Request::getPsrRequest();
+        if (!isset($this->request)) {
+            $this->request = Request::getPsrRequest();
+        }
 
-        $headers = Sprout::getHeaders();
-        $this->response = new Response(200, $headers);
+        if (!isset($this->response)) {
+            $headers = Sprout::getHeaders();
+            $this->response = new Response(200, $headers);
+        }
     }
 
 
@@ -102,6 +119,8 @@ abstract class BaseController
      */
     public function _run($method, $args)
     {
+        $this->init();
+
         try {
             $reflect = new ReflectionMethod($this, $method);
 

--- a/src/sprout/Controllers/BaseController.php
+++ b/src/sprout/Controllers/BaseController.php
@@ -17,11 +17,13 @@
 namespace Sprout\Controllers;
 
 use BadMethodCallException;
-use Exception;
+use InvalidArgumentException;
 use karmabunny\kb\Events;
 use Kohana;
 use Nyholm\Psr7\Response;
+use Nyholm\Psr7\Stream;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
 use ReflectionException;
 use ReflectionMethod;
 use Sprout\Helpers\ModuleInterface;
@@ -29,9 +31,12 @@ use Sprout\Helpers\Modules;
 use Sprout\Events\AfterActionEvent;
 use Sprout\Events\NotFoundEvent;
 use Sprout\Events\BeforeActionEvent;
+use Sprout\Events\RedirectEvent;
+use Sprout\Helpers\BaseView;
 use Sprout\Helpers\Html;
+use Sprout\Helpers\Json;
 use Sprout\Helpers\Sprout;
-use Sprout\Helpers\Text;
+use Sprout\Helpers\Url;
 
 /**
  * This is a true base controller.
@@ -137,6 +142,190 @@ abstract class BaseController
     public function __call($method, $args)
     {
         throw new \BadMethodCallException("Method '{$method}' not found");
+    }
+
+
+    /**
+     * Set the cache headers for the response.
+     *
+     * This requires the controller method to return the response object.
+     *
+     * @param string $expires
+     * @return void
+     */
+    public function setCacheHeaders(string $expires = '1 day'): void
+    {
+        $expires = strtotime($expires);
+        $maxAge = $expires - time();
+        $expires = gmdate('D, d M Y H:i:s', $expires) . ' GMT';
+
+        $this->response = $this->response
+            ->withHeader('Expires', $expires)
+            ->withHeader('Pragma', 'cache')
+            ->withHeader('Cache-Control', 'max-age=' . $maxAge);
+    }
+
+
+    /**
+     * Stream a response to the client.
+     *
+     * @param resource|StreamInterface $stream
+     * @param null|string $contentType
+     * @return ResponseInterface
+     * @throws InvalidArgumentException
+     */
+    public function stream($stream, ?string $contentType = null): ResponseInterface
+    {
+        if (is_resource($stream)) {
+            $stream = new Stream($stream);
+        }
+
+        $status = $this->response->getStatusCode();
+        $headers = $this->response->getHeaders();
+
+        if ($contentType) {
+            $headers['Content-Type'] = [$contentType];
+        }
+
+        $this->response = new Response($status, $headers, $stream);
+        return $this->response;
+    }
+
+
+    /**
+     * Render a JSON response.
+     *
+     * @param array $data
+     * @return ResponseInterface
+     */
+    public function json(array $data): ResponseInterface
+    {
+        $status = $this->response->getStatusCode();
+        $headers = $this->response->getHeaders();
+        $headers['Content-Type'] = ['application/json; charset=utf-8'];
+
+        $body = Json::encode($data);
+
+        $this->response = new Response($status, $headers, $body);
+        return $this->response;
+    }
+
+
+    /**
+     * Render a text response.
+     *
+     * @param string $text
+     * @return ResponseInterface
+     */
+    public function text(string $text): ResponseInterface
+    {
+        $status = $this->response->getStatusCode();
+        $headers = $this->response->getHeaders();
+        $headers['Content-Type'] = ['text/plain; charset=utf-8'];
+
+        $this->response = new Response($status, $headers, $text);
+        return $this->response;
+    }
+
+
+    /**
+     * Render an html response.
+     *
+     * @param string $html
+     * @return ResponseInterface
+     */
+    public function html(string $html): ResponseInterface
+    {
+        $status = $this->response->getStatusCode();
+        $headers = $this->response->getHeaders();
+        $headers['Content-Type'] = ['text/html; charset=utf-8'];
+
+        $this->response = new Response($status, $headers, $html);
+        return $this->response;
+    }
+
+
+    /**
+     * Render a view response.
+     *
+     * @param string $view
+     * @param array $data
+     * @return ResponseInterface
+     */
+    public function render(string $view, array $data = []): ResponseInterface
+    {
+        $status = $this->response->getStatusCode();
+        $headers = $this->response->getHeaders();
+        $headers['Content-Type'] = ['text/html; charset=utf-8'];
+
+        $view = BaseView::create($view, $data);
+        $body = $view->render();
+
+        $this->response = new Response($status, $headers, $body);
+        return $this->response;
+    }
+
+
+    /**
+     * Redirect to a new URL.
+     *
+     * @param string $uri
+     * @param int|string $method
+     * @return ResponseInterface
+     */
+    public function redirect(string $uri, $method = 302): ResponseInterface
+    {
+        static $CODES = [
+            'refresh' => 'Refresh',
+            '300' => 'Multiple Choices',
+            '301' => 'Moved Permanently',
+            '302' => 'Found',
+            '303' => 'See Other',
+            '304' => 'Not Modified',
+            '305' => 'Use Proxy',
+            '307' => 'Temporary Redirect'
+        ];
+
+        // HTTP headers expect absolute URLs
+        if (strpos($uri, '://') === false) {
+            $uri = Url::site($uri, true);
+        }
+
+        // Validate the method and default to 302
+        $method = isset($CODES[$method]) ? (string) $method : '302';
+
+        $body = "<h1>{$method} - {$CODES[$method]}</h1>";
+
+        if ($method === '300') {
+            $uri = (array) $uri;
+
+            $body .= '<ul>';
+            foreach ($uri as $link) {
+                $body .= '<li>' . Html::anchor($link) . '</li>';
+            }
+            $body .= '</ul>';
+
+            // The first URI will be used for the Location header
+            $uri = $uri[0];
+        } else {
+            $body .= '<p>'.Html::anchor($uri).'</p>';
+        }
+
+        // Run the redirect event
+        $event = new RedirectEvent(['uri' => $uri]);
+        Events::trigger(static::class, $event);
+        $uri = $event->uri;
+
+        $headers = $this->response->getHeaders();
+
+        if ($method === 'refresh') {
+            $headers['Refresh'] = [0, "url={$uri}"];
+        } else {
+            $headers['Location'] = [$uri];
+        }
+
+        $this->response = new Response($method, $headers, $body);
+        return $this->response;
     }
 
 

--- a/src/sprout/Controllers/BaseController.php
+++ b/src/sprout/Controllers/BaseController.php
@@ -173,7 +173,6 @@ abstract class BaseController
 
         $this->response = $this->response
             ->withHeader('Expires', $expires)
-            ->withHeader('Pragma', 'cache')
             ->withHeader('Cache-Control', 'max-age=' . $maxAge);
     }
 

--- a/src/sprout/Controllers/BaseController.php
+++ b/src/sprout/Controllers/BaseController.php
@@ -184,10 +184,16 @@ abstract class BaseController
      *
      * @param string $expires
      * @return void
+     * @throws InvalidArgumentException if the expires date is invalid
      */
     public function setCacheHeaders(string $expires = '1 day'): void
     {
         $expires = strtotime($expires);
+
+        if ($expires === false) {
+            throw new InvalidArgumentException('Invalid expires date');
+        }
+
         $maxAge = $expires - time();
         $expires = gmdate('D, d M Y H:i:s', $expires) . ' GMT';
 

--- a/src/sprout/Controllers/BaseController.php
+++ b/src/sprout/Controllers/BaseController.php
@@ -332,7 +332,7 @@ abstract class BaseController
 
         if ($method === 'refresh') {
             $status = 200;
-            $headers['Refresh'] = [0, "url={$uri}"];
+            $headers['Refresh'] = ["0; url={$uri}"];
         } else {
             $status = (int) $method;
             $headers['Location'] = [$uri];

--- a/src/sprout/Controllers/BaseController.php
+++ b/src/sprout/Controllers/BaseController.php
@@ -20,6 +20,8 @@ use BadMethodCallException;
 use Exception;
 use karmabunny\kb\Events;
 use Kohana;
+use Nyholm\Psr7\Response;
+use Psr\Http\Message\ResponseInterface;
 use ReflectionException;
 use ReflectionMethod;
 use Sprout\Helpers\ModuleInterface;
@@ -44,6 +46,18 @@ abstract class BaseController
     // Allow all controllers to run in production by default
     const ALLOW_PRODUCTION = TRUE;
 
+
+    /**
+     * A response object to send to the client.
+     *
+     * If returned from a controller method this is then processed and sent
+     * to the client. Otherwise it's ignored and standard echo output is used.
+     *
+     * @var ResponseInterface
+     */
+    public ResponseInterface $response;
+
+
     /**
      * @return  void
      */
@@ -54,6 +68,9 @@ abstract class BaseController
             // Set the instance to the first controller loaded
             Kohana::$instance = $this;
         }
+
+        $headers = Sprout::getHeaders();
+        $this->response = new Response(200, $headers);
     }
 
 

--- a/src/sprout/Controllers/CronJobController.php
+++ b/src/sprout/Controllers/CronJobController.php
@@ -33,6 +33,8 @@ class CronJobController extends Controller
         }
         Kohana::closeBuffers();
         $_ENV['CRON'] = 1;
+
+        parent::__construct();
     }
 
 

--- a/src/sprout/Helpers/Request.php
+++ b/src/sprout/Helpers/Request.php
@@ -24,6 +24,8 @@ use karmabunny\kb\Url as KbUrl;
 use karmabunny\kb\UrlDecodeException;
 use karmabunny\kb\XML;
 use karmabunny\kb\XMLException;
+use Nyholm\Psr7\ServerRequest;
+use Psr\Http\Message\ServerRequestInterface;
 
 /**
  * Get information about the incoming HTTP request.
@@ -767,5 +769,34 @@ class Request
         return $body;
     }
 
+
+    /**
+     * Get a PSR-7 request object.
+     *
+     * @return ServerRequestInterface
+     */
+    public static function getPsrRequest(): ServerRequestInterface
+    {
+        $protocol = self::protocol();
+        $host = $_SERVER['HTTP_HOST'] ?? $_SERVER['SERVER_NAME'] ?? Kohana::config('config.cli_domain');
+
+        $method = strtoupper(self::method());
+        $uri = "{$protocol}://{$host}/" . Router::$current_uri;
+        $headers = self::getHeaders();
+        $body = null;
+
+        if (!in_array($method, ['GET', 'HEAD', 'OPTIONS'])) {
+            $body = fopen('php://input', 'r');
+        }
+
+        return new ServerRequest(
+            $method,
+            $uri,
+            $headers,
+            $body,
+            '1.1',
+            $_SERVER
+        );
+    }
 
 } // End request

--- a/src/sprout/Helpers/Request.php
+++ b/src/sprout/Helpers/Request.php
@@ -777,11 +777,11 @@ class Request
      */
     public static function getPsrRequest(): ServerRequestInterface
     {
-        $protocol = self::protocol();
-        $host = $_SERVER['HTTP_HOST'] ?? $_SERVER['SERVER_NAME'] ?? Kohana::config('config.cli_domain');
+        $protocol = self::protocol() ?: 'http';
+        $host = $_SERVER['HTTP_HOST'] ?? $_SERVER['SERVER_NAME'] ?? Kohana::config('config.cli_domain') ?? 'localhost';
 
         $method = strtoupper(self::method());
-        $uri = "{$protocol}://{$host}/" . Router::$current_uri;
+        $uri = "{$protocol}://{$host}/" . Router::$complete_uri;
         $headers = self::getHeaders();
         $body = null;
 

--- a/src/sprout/Helpers/Sprout.php
+++ b/src/sprout/Helpers/Sprout.php
@@ -965,6 +965,24 @@ class Sprout
 
 
     /**
+     * Get the headers that are queued to be sent.
+     *
+     * @return array
+     */
+    public static function getHeaders(): array
+    {
+        $headers = [];
+
+        foreach (headers_list() as $header) {
+            [$name, $value] = explode(':', $header, 2) + ['', ''];
+            $headers[$name] = $value;
+        }
+
+        return $headers;
+    }
+
+
+    /**
      * Render out a response object.
      *
      * Note this doesn't fire any system events.

--- a/src/sprout/Helpers/Sprout.php
+++ b/src/sprout/Helpers/Sprout.php
@@ -983,6 +983,28 @@ class Sprout
 
 
     /**
+     * Remove all headers from the response.
+     *
+     * @return bool True if headers were removed, false if headers were already sent
+     */
+    public static function removeHeaders(): bool
+    {
+        if (headers_sent()) {
+            return false;
+        }
+
+        $headers = headers_list();
+
+        foreach ($headers as $header) {
+            [$name] = explode(':', $header, 2);
+            header_remove($name);
+        }
+
+        return true;
+    }
+
+
+    /**
      * Render out a response object.
      *
      * Note this doesn't fire any system events.

--- a/src/sprout/Helpers/Sprout.php
+++ b/src/sprout/Helpers/Sprout.php
@@ -1007,10 +1007,20 @@ class Sprout
             return false;
         }
 
-        $headers = headers_list();
+        if (PHP_SAPI === 'cli' and function_exists('xdebug_get_headers')) {
+            $getHeaders = 'xdebug_get_headers';
+        } else {
+            $getHeaders = 'headers_list';
+        }
 
-        foreach ($headers as $header) {
-            [$name] = explode(':', $header, 2);
+        foreach ($getHeaders() as $header) {
+            $index = strpos($header, ':');
+
+            if ($index === false) {
+                continue;
+            }
+
+            $name = substr($header, 0, $index);
             header_remove($name);
         }
 

--- a/src/sprout/Helpers/Sprout.php
+++ b/src/sprout/Helpers/Sprout.php
@@ -973,8 +973,22 @@ class Sprout
     {
         $headers = [];
 
-        foreach (headers_list() as $header) {
-            [$name, $value] = explode(':', $header, 2) + ['', ''];
+        if (PHP_SAPI === 'cli' and function_exists('xdebug_get_headers')) {
+            $getHeaders = 'xdebug_get_headers';
+        } else {
+            $getHeaders = 'headers_list';
+        }
+
+        foreach ($getHeaders() as $header) {
+            $index = strpos($header, ':');
+
+            if ($index === false) {
+                continue;
+            }
+
+            $name = substr($header, 0, $index);
+            $value = ltrim(substr($header, $index + 1), ' ');
+
             $headers[$name] = $value;
         }
 

--- a/src/sprout/Welcome/Controllers/WelcomeController.php
+++ b/src/sprout/Welcome/Controllers/WelcomeController.php
@@ -47,6 +47,7 @@ class WelcomeController extends Controller
 
     public function __construct()
     {
+        parent::__construct();
         Session::instance();
     }
 
@@ -54,7 +55,7 @@ class WelcomeController extends Controller
     /**
      * Redirect home page traffic to the welcome checklist
      */
-    public function redirect()
+    public function index()
     {
         Url::redirect('welcome/checklist');
     }

--- a/src/sprout/Welcome/config/routes.php
+++ b/src/sprout/Welcome/config/routes.php
@@ -17,7 +17,7 @@
 $ns = 'Sprout\Welcome\\Controllers\\';
 
 // Redirect traffic to the home page into the welcome system
-$config['_default'] = $ns . 'WelcomeController/redirect';
+$config['_default'] = $ns . 'WelcomeController/index';
 
 // Useful tools
 $config['welcome/info'] = $ns . 'WelcomeController/phpInfo';

--- a/src/sprout/core/Kohana.php
+++ b/src/sprout/core/Kohana.php
@@ -303,6 +303,8 @@ final class Kohana {
             $res = $controller->_run(Router::$method, Router::$arguments);
 
             if ($res instanceof ResponseInterface) {
+                ob_clean();
+                Sprout::removeHeaders();
                 Sprout::send($res);
             }
 


### PR DESCRIPTION
Some builtin helpers combined with an instance of `Response` to make control flow within controllers a bit nicer. 

At the moment our classic render/redirect methods all use an immediate `exit()` which is a bit crude if you want to modify the output on the way out. This is more elegant, especially when building complex API controllers.

The additional `Request` object aims to do two things:
1. Easier integration with 3rd party middlewares.
2. Discourage use of superglobals to make controllers unit-testable.

This doesn't prevent existing behaviours and patterns. This lives side-by-side for any new developments that want to use it.