### PR TITLE
JS to change input colour and issue alert in non-dev

### DIFF
--- a/src/sprout/media/js/dbtools_sql.js
+++ b/src/sprout/media/js/dbtools_sql.js
@@ -7,13 +7,45 @@ $(document).ready(function() {
 });
 
 $(document).ready(function() {
-    var $submit = $('textarea.sql').closest('form').find('.save');
+    // Statements that write to, or restructure, the database
+    var DESTRUCTIVE = /\b(ALTER|CREATE|DELETE|DROP|GRANT|INSERT|RENAME|REPLACE|REVOKE|TRUNCATE|UPDATE)\b/i;
 
-    $('textarea.sql').keypress(function() {
-        if ($(this).val().match(/UPDATE|DELETE|REPLACE|ALTER|TRUNCATE|DROP/i)) {
-            $submit.addClass('warn');
-        } else {
-            $submit.removeClass('warn');
+    // Environments where a destructive query doesn't need confirming
+    var SAFE_ENVIRONMENTS = ['dev', 'qa'];
+
+    var $sql = $('textarea.sql');
+    if (!$sql.length) return;
+
+    var $form = $sql.closest('form');
+    var $submit = $form.find('.save');
+
+    var environment = $.trim(String($form.data('environment') || '')).toLowerCase();
+    var confirm_destructive = $.inArray(environment, SAFE_ENVIRONMENTS) === -1;
+
+    var isDestructive = function() {
+        return DESTRUCTIVE.test($sql.val());
+    };
+
+    var refreshSubmit = function() {
+        var destructive = isDestructive();
+        $submit
+            .toggleClass('warn button-red', destructive)
+            .toggleClass('button-green', !destructive);
+    };
+
+    // 'input' also covers pasting and undo, which 'keypress' misses
+    $sql.on('input change', refreshSubmit);
+    refreshSubmit();
+
+    $form.on('submit', function(event) {
+        if (!confirm_destructive) return;
+        if (!isDestructive()) return;
+
+        var message = 'This query changes data, and you\'re on the "' + environment + '" environment.'
+            + '\n\nRun it anyway?';
+
+        if (!window.confirm(message)) {
+            event.preventDefault();
         }
     });
 });

--- a/src/sprout/views/dbtools/sql.php
+++ b/src/sprout/views/dbtools/sql.php
@@ -4,7 +4,7 @@ use Sprout\Helpers\Enc;
 ?>
 
 
-<form action="" method="post">
+<form action="" method="post" data-environment="<?= Enc::html(defined('ENVIRONMENT') ? ENVIRONMENT : ''); ?>">
 	<?= Csrf::token(); ?>
 	<div class="sql-wrapper white-box -clearfix">
 


### PR DESCRIPTION
This is intended to make it hard to accidentally clobber prod data Which is otherwise easy to do with multiple tabs open.

The previous 'warn' class didn't seem to actually do anything either
There is a small friction in performing destructive queries in non-dev/qa environments, but I believe it's a sane tradeoff.

<img width="1473" height="979" alt="image" src="https://github.com/user-attachments/assets/5d565af7-8986-4ea5-aae9-213fd6183e1c" />

<img width="1463" height="828" alt="image" src="https://github.com/user-attachments/assets/2db70c22-07f8-4dc6-a4c3-32961927b095" />

<img width="1447" height="950" alt="image" src="https://github.com/user-attachments/assets/f95e6628-f61e-41f0-9569-c98f24731eef" />

